### PR TITLE
Write API calls for questions and categories data

### DIFF
--- a/api/categoriesData.js
+++ b/api/categoriesData.js
@@ -1,0 +1,32 @@
+import { clientCredentials } from '../utils/client';
+
+const ENDPOINT = clientCredentials.databaseURL;
+
+const getCategories = () => new Promise((resolve, reject) => {
+  fetch(`${ENDPOINT}/categories.json`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application.json',
+    },
+  })
+    .then((response) => response.json())
+    .then((data) => resolve(data ? Object.values(data) : []))
+    .catch(reject);
+});
+
+const getCategoryById = (firebaseKey) => new Promise((resolve, reject) => {
+  fetch(`${ENDPOINT}/categories/${firebaseKey}.json`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application.json',
+    },
+  })
+    .then((response) => response.json())
+    .then(resolve)
+    .catch(reject);
+});
+
+export {
+  getCategories,
+  getCategoryById,
+};

--- a/api/questionsData.js
+++ b/api/questionsData.js
@@ -1,0 +1,86 @@
+import { clientCredentials } from '../utils/client';
+
+const ENDPOINT = clientCredentials.databaseURL;
+
+const getQuestions = () => new Promise((resolve, reject) => {
+  fetch(`${ENDPOINT}/questions.json`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application.json',
+    },
+  })
+    .then((response) => response.json())
+    .then((data) => resolve(data ? Object.values(data) : []))
+    .catch(reject);
+});
+
+const getQuestionsByHost = (uid) => new Promise((resolve, reject) => {
+  fetch(`${ENDPOINT}/questions.json?orderBy="uid"&equalTo="${uid}"`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application.json',
+    },
+  })
+    .then((response) => response.json())
+    .then((data) => resolve(data ? Object.values(data) : []))
+    .catch(reject);
+});
+
+const getQuestionById = (firebaseKey) => new Promise((resolve, reject) => {
+  fetch(`${ENDPOINT}/questions/${firebaseKey}.json`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application.json',
+    },
+  })
+    .then((response) => response.json())
+    .then(resolve)
+    .catch(reject);
+});
+
+const createQuestion = (payload) => new Promise((resolve, reject) => {
+  fetch(`${ENDPOINT}/questions.json`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application.json',
+    },
+    body: JSON.stringify(payload),
+  })
+    .then((response) => response.json())
+    .then(resolve)
+    .catch(reject);
+});
+
+const updateQuestion = (payload) => new Promise((resolve, reject) => {
+  fetch(`${ENDPOINT}/questions/${payload.firebaseKey}.json`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application.json',
+    },
+    body: JSON.stringify(payload),
+  })
+    .then((response) => response.json())
+    .then(resolve)
+    .catch(reject);
+});
+
+const deleteQuestion = (firebaseKey) => new Promise((resolve, reject) => {
+  fetch(`${ENDPOINT}/questions/${firebaseKey}.json`, {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application.json',
+    },
+  })
+    .then((response) => response.json())
+    .then(resolve)
+    .catch(reject);
+});
+
+export {
+  getQuestions,
+  getQuestionsByHost,
+  getQuestionById,
+  createQuestion,
+  updateQuestion,
+  deleteQuestion,
+};

--- a/pages/question/[id].js
+++ b/pages/question/[id].js
@@ -5,5 +5,5 @@ export default function ReviewQuestion() {
     <div>
       Player view question
     </div>
-  )
+  );
 }


### PR DESCRIPTION
## Description
Added code for API calls for questions (questionsData.js) and categories (categoryData.js), including:
getQuestions (READ all questions in database; will likely be deprecated on addition of games in stretch)
getQuestionsByHost (READ questions by UID)
getQuestionById (READ question by firebaseKey
createQuestion (POST question via payload)
updateQuestion (PATCH question by firebaseKey included on payload)
deleteQuestion (DELETE question by firebaseKey)
getCategories (READ all categories)
getCategoryById (READ category by firebaseKey)

Does not include code to test calls in app (tested in Postman)

## Related Issue
#4 

## Motivation and Context
Creates link between users and database

## How Can This Be Tested?
Test endpoints in Postman
Else, will be double-checked as corresponding functionality is built

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
