### PR TITLE
View All Questions

### DIFF
--- a/api/categoriesData.js
+++ b/api/categoriesData.js
@@ -10,7 +10,7 @@ const getCategories = () => new Promise((resolve, reject) => {
     },
   })
     .then((response) => response.json())
-    .then((data) => resolve(data ? Object.values(data) : []))
+    .then((data) => resolve(data))
     .catch(reject);
 });
 

--- a/api/mergedData.js
+++ b/api/mergedData.js
@@ -1,0 +1,11 @@
+import { getCategories } from './categoriesData';
+import { getQuestionsByHostNoCats } from './questionsData';
+
+const getQuestionsByHost = async (uid) => {
+  const questions = await getQuestionsByHostNoCats(uid);
+  const categories = await getCategories();
+  const qWithCats = questions.map((q) => ({ ...q, category: categories[q.categoryId] }));
+  return qWithCats;
+};
+
+export default getQuestionsByHost;

--- a/api/questionsData.js
+++ b/api/questionsData.js
@@ -14,7 +14,7 @@ const getQuestions = () => new Promise((resolve, reject) => {
     .catch(reject);
 });
 
-const getQuestionsByHost = (uid) => new Promise((resolve, reject) => {
+const getQuestionsByHostNoCats = (uid) => new Promise((resolve, reject) => {
   fetch(`${ENDPOINT}/questions.json?orderBy="uid"&equalTo="${uid}"`, {
     method: 'GET',
     headers: {
@@ -78,7 +78,7 @@ const deleteQuestion = (firebaseKey) => new Promise((resolve, reject) => {
 
 export {
   getQuestions,
-  getQuestionsByHost,
+  getQuestionsByHostNoCats,
   getQuestionById,
   createQuestion,
   updateQuestion,

--- a/components/NavBarAuth.js
+++ b/components/NavBarAuth.js
@@ -34,7 +34,7 @@ export default function NavBarAuth() {
             </Link>
           </>
         ) : (
-          <Link passHref href="/host/game">
+          <Link passHref href="/host/questions">
             <button type="button">Switch to Host View</button>
           </Link>
         )}

--- a/components/QuestionCard.js
+++ b/components/QuestionCard.js
@@ -1,9 +1,38 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+import Link from 'next/link';
 
-export default function QuestionCard() {
+export default function QuestionCard({ questionObj }) {
   return (
-    <div>
-      Question Preview
-    </div>
+    <Link passHref href={`/host/question/${questionObj.firebaseKey}`}>
+      <div className="q-card">
+        <div className="q-card-tags">
+          <p className="q-category" style={{ background: `${questionObj.category.color}` }}>
+            {questionObj.category.name.toUpperCase()}
+          </p>
+          <p className={`q-status status-${questionObj.status}`}>
+            {questionObj.status.toUpperCase()}
+          </p>
+          <p className="q-timestamp">{questionObj.status === 'closed' && (`Last Used: ${questionObj.timeOpened.split('T')[0]}`)}</p>
+        </div>
+        <p className="q-card-text">
+          {questionObj.question}
+        </p>
+      </div>
+    </Link>
   );
 }
+
+QuestionCard.propTypes = {
+  questionObj: PropTypes.shape({
+    question: PropTypes.string,
+    answer: PropTypes.string,
+    status: PropTypes.string,
+    timeOpened: PropTypes.string,
+    firebaseKey: PropTypes.string,
+    category: PropTypes.shape({
+      name: PropTypes.string,
+      color: PropTypes.string,
+    }),
+  }).isRequired,
+};

--- a/pages/host/questions.js
+++ b/pages/host/questions.js
@@ -1,9 +1,28 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useAuth } from '../../utils/context/authContext';
+import QuestionCard from '../../components/QuestionCard';
+import getQuestionsByHost from '../../api/mergedData';
 
 export default function HostQuestions() {
+  const [questions, setQuestions] = useState([]);
+  const { user } = useAuth();
+
+  useEffect(() => {
+    getQuestionsByHost(user.uid).then(setQuestions);
+  }, []);
+
   return (
-    <div>
-      Display questions database
-    </div>
+    <>
+      <div className="questions-header">
+        <h1 className="page-header">Questions</h1>
+        <Link passHref href="/host/question/new">
+          <button type="button">New Question</button>
+        </Link>
+      </div>
+      <div className="question-container">
+        {questions.length ? questions.map((q) => <QuestionCard key={q.firebaseKey} questionObj={q} />) : (<span>Loading Questions</span>)}
+      </div>
+    </>
   );
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -17,7 +17,7 @@ function Home() {
           <p>Enter As Player</p>
         </div>
         <div>
-          <Link passHref href="/host/game">
+          <Link passHref href="/host/questions">
             <button type="button">HOST</button>
           </Link>
           <p>Enter As Host</p>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -112,3 +112,76 @@ body {
     font-size: 75px;
   }
 }
+
+.page-header {
+  font-size: 10rem;
+  color: aliceblue;
+}
+
+.question-container {
+  display: flex;
+  flex-flow: row wrap;
+  gap: 10px;
+  justify-content: space-between;
+}
+
+.q-card {
+  background: aliceblue;
+  width: 300px;
+  min-width: 300px;
+  min-height: 3.5rem;
+  height: auto;
+  padding: 5px 0 0 0;
+  margin-bottom: auto;
+  max-height: 3rem;
+  overflow: hidden;
+  transition: max-height 1s;
+  border-radius: 5px;
+  /* transition-timing-function: ease-in-out; */
+  box-shadow: inset 0 0 3px black;
+  .q-card-text {
+    margin: 0;
+    padding: 0 10px 5px 10px;
+  }
+  cursor: pointer;
+}
+
+.q-card:hover {
+  max-height: 200px;
+}
+
+.status-unused {
+  background: #96dbdb;
+}
+
+.status-open {
+  background: #82e782;
+}
+
+.status-closed {
+  background: #e67c7c;
+}
+
+.q-card-tags {
+  float: right;
+  width: auto;
+  align-content: center;
+  margin: 0 6px;
+  padding: 0;
+  text-align: right;
+}
+
+.q-category, .q-status {
+  display: inline-block;
+  border-radius: 5px;
+  font-size: 0.7rem;
+  padding: 3px 6px;
+  box-shadow: inset 0 0 3px #454949;
+  width: auto;
+  margin: 0 2px;
+}
+
+.q-timestamp {
+  font-size: 0.7rem;
+  margin: 0 2px;
+}


### PR DESCRIPTION
## Description
Populated /host/questions with user-specific question data
Cards display question, category, and status of question
Clicking on a card takes user to question details page (/host/question/[id])
Changed /host/questions to landing page in host terminal (not developing /host/game until stretch)

## Related Issue
#12 

## Motivation and Context
As a host user, I want to be able to see all the questions in my database. I also want to see at a glance which questions have been used already, and what category each question is in.

## How Can This Be Tested?
Logged into welcome screen, select 'HOST'
View below should be visible (with user-specific data)
Hover over cards to expand and read full question
Clicking on a card should push to /host/question/[id] (page unbuilt)

## Screenshots (if appropriate):
![image](https://github.com/alexberka/a-trivial-glance/assets/148516337/91f4e9aa-18d0-488c-89bd-9c7f48673ea5)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
