### PR TITLE
View Question Details

### DIFF
--- a/api/mergedData.js
+++ b/api/mergedData.js
@@ -1,5 +1,5 @@
-import { getCategories } from './categoriesData';
-import { getQuestionsByHostNoCats } from './questionsData';
+import { getCategories, getCategoryById } from './categoriesData';
+import { getQuestionByIdNoCat, getQuestionsByHostNoCats } from './questionsData';
 
 const getQuestionsByHost = async (uid) => {
   const questions = await getQuestionsByHostNoCats(uid);
@@ -8,4 +8,13 @@ const getQuestionsByHost = async (uid) => {
   return qWithCats;
 };
 
-export default getQuestionsByHost;
+const getQuestionById = async (firebaseKey) => {
+  const question = await getQuestionByIdNoCat(firebaseKey);
+  const category = await getCategoryById(question.categoryId);
+  return { ...question, category };
+};
+
+export {
+  getQuestionsByHost,
+  getQuestionById,
+};

--- a/api/questionsData.js
+++ b/api/questionsData.js
@@ -26,7 +26,7 @@ const getQuestionsByHostNoCats = (uid) => new Promise((resolve, reject) => {
     .catch(reject);
 });
 
-const getQuestionById = (firebaseKey) => new Promise((resolve, reject) => {
+const getQuestionByIdNoCat = (firebaseKey) => new Promise((resolve, reject) => {
   fetch(`${ENDPOINT}/questions/${firebaseKey}.json`, {
     method: 'GET',
     headers: {
@@ -79,7 +79,7 @@ const deleteQuestion = (firebaseKey) => new Promise((resolve, reject) => {
 export {
   getQuestions,
   getQuestionsByHostNoCats,
-  getQuestionById,
+  getQuestionByIdNoCat,
   createQuestion,
   updateQuestion,
   deleteQuestion,

--- a/components/QuestionDetails.js
+++ b/components/QuestionDetails.js
@@ -1,0 +1,64 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Image } from 'react-bootstrap';
+
+export default function QuestionDetails({ questionObj, host }) {
+  return (
+    <div className="question-details">
+      <div className="qd-info">
+        <div>
+          <h2>Question</h2>
+          <hr />
+          <h4>{questionObj.question}</h4>
+        </div>
+        {questionObj.image && (<Image className="qd-image" src={questionObj.image} />)}
+        <div>
+          <h2>Answer</h2>
+          <hr />
+          <h4>{questionObj.answer}</h4>
+        </div>
+      </div>
+      <div className="qd-buttons">
+        <p className="qd-category" style={{ background: `${questionObj.category.color}` }}>
+          {questionObj.category.name.toUpperCase()}
+        </p>
+        <p className={`qd-status status-${questionObj.status}`}>
+          {questionObj.status.toUpperCase()}
+        </p>
+        <p className="qd-timestamp">{questionObj.status === 'closed' && (`Last Used: ${questionObj.timeOpened.split('T')[0]}`)}</p>
+        {host && (
+          <div className="qd-host-tools">
+            {questionObj.status === 'closed' && (<button type="button">Reset</button>)}
+            <button type="button">
+              {questionObj.status === 'unused' && 'Open'}
+              {questionObj.status === 'open' && 'Close'}
+              {questionObj.status === 'closed' && 'Reopen'}
+            </button>
+            <button type="button">Edit</button>
+            <button type="button">Delete</button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+QuestionDetails.propTypes = {
+  questionObj: PropTypes.shape({
+    question: PropTypes.string,
+    image: PropTypes.string,
+    answer: PropTypes.string,
+    status: PropTypes.string,
+    timeOpened: PropTypes.string,
+    firebaseKey: PropTypes.string,
+    category: PropTypes.shape({
+      name: PropTypes.string,
+      color: PropTypes.string,
+    }),
+  }).isRequired,
+  host: PropTypes.bool,
+};
+
+QuestionDetails.defaultProps = {
+  host: false,
+};

--- a/pages/host/question/[id].js
+++ b/pages/host/question/[id].js
@@ -1,9 +1,19 @@
-import React from 'react';
+import { useRouter } from 'next/router';
+import React, { useEffect, useState } from 'react';
+import { getQuestionById } from '../../../api/mergedData';
+import QuestionDetails from '../../../components/QuestionDetails';
 
 export default function ManageQuestion() {
+  const router = useRouter();
+  const [question, setQuestion] = useState({});
+
+  useEffect(() => {
+    getQuestionById(router.query.id).then(setQuestion);
+  }, []);
+
   return (
     <div>
-      Display Question View
+      {question.question && <QuestionDetails questionObj={question} host />}
     </div>
   );
 }

--- a/pages/host/questions.js
+++ b/pages/host/questions.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useAuth } from '../../utils/context/authContext';
 import QuestionCard from '../../components/QuestionCard';
-import getQuestionsByHost from '../../api/mergedData';
+import { getQuestionsByHost } from '../../api/mergedData';
 
 export default function HostQuestions() {
   const [questions, setQuestions] = useState([]);
@@ -17,7 +17,7 @@ export default function HostQuestions() {
       <div className="questions-header">
         <h1 className="page-header">Questions</h1>
         <Link passHref href="/host/question/new">
-          <button type="button">New Question</button>
+          <button type="button" className="">New Question</button>
         </Link>
       </div>
       <div className="question-container">

--- a/pages/question/[id].js
+++ b/pages/question/[id].js
@@ -1,9 +1,19 @@
-import React from 'react';
+import { useRouter } from 'next/router';
+import React, { useEffect, useState } from 'react';
+import QuestionDetails from '../../components/QuestionDetails';
+import { getQuestionById } from '../../api/mergedData';
 
 export default function ReviewQuestion() {
+  const router = useRouter();
+  const [question, setQuestion] = useState({});
+
+  useEffect(() => {
+    getQuestionById(router.query.id).then(setQuestion);
+  }, []);
+
   return (
     <div>
-      Player view question
+      {question.question && <QuestionDetails questionObj={question} />}
     </div>
   );
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -50,6 +50,7 @@ body {
   text-align: center;
   padding: 10px 0;
   border-bottom-right-radius: 5px;
+  z-index: 4;
   hr {
     border-color: aliceblue;
     margin: 3px;
@@ -184,4 +185,58 @@ body {
 .q-timestamp {
   font-size: 0.7rem;
   margin: 0 2px;
+}
+
+.question-details {
+  padding-top: 20px;
+  display: flex;
+  gap: 20px;
+  color: aliceblue;
+  .qd-info {
+    width: 90%;
+    h2 {
+      padding-top: 5px;
+      margin-bottom: 5px;
+    }
+    hr {
+      border: 2px solid aliceblue;
+      opacity: 60%;
+      padding: 0;
+      margin: 0;
+    }
+    h4 {
+      padding: 5px;
+    }
+    .qd-image {
+      display: block;
+      max-height: 300px;
+      border: 1px solid black;
+      border-radius: 5px;
+      box-shadow: 0 0 3px black;
+      margin: 0 auto;
+    }
+  }
+  .qd-buttons {
+    color: black;
+    position: relative;
+    height: 90vh;
+    text-align: center;
+    button, p {
+      border-radius: 5px;
+      margin: 5px 0;
+      font-size: 1.2rem;
+      padding: 5px 10px;
+      width: 100%;
+    }
+    .qd-host-tools {
+      position: absolute;
+      width: 100%;
+      bottom: 0px;
+      right: 0px;
+      button {
+        display: block;
+      }
+    }
+  }
+  
 }


### PR DESCRIPTION
## Description
Developed /host/question/[id] page to display question details
Added QuestionDetails.js component for use across similar pages

## Related Issue
#13 

## Motivation and Context
As a host user, I want to be able to see all of a question's details and have access to edit/delete capabilities

## How Can This Be Tested?
From the /host/questions page, click on a question. It will open up the question details page. Question, answer, image (if there is one), category, status, last used (if applicable), open/close/reopen, edit, and delete are all on the page.

## Screenshots (if appropriate):
![image](https://github.com/alexberka/a-trivial-glance/assets/148516337/70c0600a-beb7-4fce-bb4d-0c87b1fea600)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
