### PR TITLE
Functionality to edit question

### DIFF
--- a/api/mergedData.js
+++ b/api/mergedData.js
@@ -10,7 +10,7 @@ const getQuestionsByHost = async (uid) => {
 
 const getQuestionById = async (firebaseKey) => {
   const question = await getQuestionByIdNoCat(firebaseKey);
-  const category = await getCategoryById(question.categoryId);
+  const category = question ? await getCategoryById(question.categoryId) : null;
   return { ...question, category };
 };
 

--- a/components/QuestionDetails.js
+++ b/components/QuestionDetails.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Image } from 'react-bootstrap';
+import CategoryDropdown from './forms/CategoryDropdown';
 
-export default function QuestionDetails({ questionObj, host }) {
+export default function QuestionDetails({ questionObj, host, onUpdate }) {
   return (
     <div className="question-details">
       <div className="qd-info">
@@ -19,22 +20,31 @@ export default function QuestionDetails({ questionObj, host }) {
         </div>
       </div>
       <div className="qd-buttons">
-        <p className="qd-category" style={{ background: `${questionObj.category.color}` }}>
-          {questionObj.category.name.toUpperCase()}
-        </p>
+        {host ? (
+          <CategoryDropdown selectedCategoryId={questionObj.category.firebaseKey} questionId={questionObj.firebaseKey} />
+        ) : (
+          <p className="qd-status" style={{ background: `${questionObj.category.color}` }}>
+            {questionObj.category.name.toUpperCase()}
+          </p>
+        )}
         <p className={`qd-status status-${questionObj.status}`}>
           {questionObj.status.toUpperCase()}
         </p>
-        <p className="qd-timestamp">{questionObj.status === 'closed' && (`Last Used: ${questionObj.timeOpened.split('T')[0]}`)}</p>
+        {host
+        && (
+        <p className="qd-timestamp">
+          {questionObj.status === 'closed' && (`Last Used: ${questionObj.timeOpened.split('T')[0]}`)}
+        </p>
+        )}
         {host && (
           <div className="qd-host-tools">
             {questionObj.status === 'closed' && (<button type="button">Reset</button>)}
             <button type="button">
-              {questionObj.status === 'unused' && 'Open'}
-              {questionObj.status === 'open' && 'Close'}
-              {questionObj.status === 'closed' && 'Reopen'}
+              {questionObj.status === 'unused' && 'Open Question'}
+              {questionObj.status === 'open' && 'Close Question'}
+              {questionObj.status === 'closed' && 'Reopen Question'}
             </button>
-            <button type="button">Edit</button>
+            <button type="button" onClick={onUpdate}>Edit</button>
             <button type="button">Delete</button>
           </div>
         )}
@@ -54,11 +64,14 @@ QuestionDetails.propTypes = {
     category: PropTypes.shape({
       name: PropTypes.string,
       color: PropTypes.string,
+      firebaseKey: PropTypes.string,
     }),
   }).isRequired,
   host: PropTypes.bool,
+  onUpdate: PropTypes.func,
 };
 
 QuestionDetails.defaultProps = {
   host: false,
+  onUpdate: null,
 };

--- a/components/forms/CategoryDropdown.js
+++ b/components/forms/CategoryDropdown.js
@@ -1,0 +1,62 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { getCategories } from '../../api/categoriesData';
+import { updateQuestion } from '../../api/questionsData';
+
+export default function CategoryDropdown({ questionId, selectedCategoryId, form }) {
+  const [categories, setCategories] = useState();
+  const [menuState, setMenuState] = useState({
+    open: false,
+    selected: selectedCategoryId,
+  });
+
+  useEffect(() => {
+    getCategories().then(setCategories);
+  }, []);
+
+  const handleToggle = () => {
+    setMenuState((prev) => ({ ...prev, open: !prev.open }));
+  };
+
+  const handleClick = (e, categoryId) => {
+    const payload = { firebaseKey: questionId, categoryId };
+    if (form) { form(e); } else { updateQuestion(payload); }
+    handleToggle();
+    setMenuState((prev) => ({ ...prev, selected: categoryId }));
+  };
+
+  return (
+    <div className="category-dropdown">
+      {categories && (
+        <div className="qd-category" style={{ background: `${form ? 'white' : categories[menuState.selected].color}` }}>
+          <div className="qd-category-name">
+            {menuState.selected ? categories[menuState.selected].name.toUpperCase() : 'Select Category'}
+          </div>
+          <button type="button" className="qd-category-toggle" onClick={handleToggle}>
+            {menuState.open ? '▲' : '▼'}
+          </button>
+        </div>
+      )}
+      {menuState.open && (
+        <div className="category-menu">
+          {Object.values(categories)
+            .sort((a, b) => a.name.localeCompare(b.name))
+            .map((cat) => (
+              <button type="button" className="category-item" key={cat.firebaseKey} name="categoryId" value={cat.firebaseKey} onClick={(e) => handleClick(e, cat.firebaseKey)}>{cat.name}</button>
+            ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+CategoryDropdown.propTypes = {
+  questionId: PropTypes.string.isRequired,
+  selectedCategoryId: PropTypes.string,
+  form: PropTypes.func,
+};
+
+CategoryDropdown.defaultProps = {
+  selectedCategoryId: '',
+  form: null,
+};

--- a/components/forms/QuestionForm.js
+++ b/components/forms/QuestionForm.js
@@ -1,9 +1,89 @@
-import React from 'react';
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { Form } from 'react-bootstrap';
+import CategoryDropdown from './CategoryDropdown';
+import { createQuestion, updateQuestion } from '../../api/questionsData';
+import { useAuth } from '../../utils/context/authContext';
 
-export default function QuestionForm() {
+const nullQuestion = {
+  question: '',
+  image: '',
+  answer: '',
+  status: 'unused',
+  timeOpened: 'never',
+  categoryId: '',
+};
+export default function QuestionForm({ questionObj, onUpdate }) {
+  const [formInput, setFormInput] = useState(questionObj);
+  const { user } = useAuth();
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormInput((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (formInput.firebaseKey) {
+      delete formInput.category;
+      updateQuestion(formInput).then(onUpdate);
+    } else {
+      const payload = { ...formInput, uid: user.uid };
+      createQuestion(payload).then(({ name }) => {
+        updateQuestion({ firebaseKey: name }).then(onUpdate);
+      });
+    }
+  };
+
   return (
-    <div>
-      Create/Edit Question
-    </div>
+    <Form className="question-details">
+      <div className="qd-info">
+        <div>
+          <h2>Question</h2>
+          <hr />
+          <Form.Control name="question" value={formInput.question || ''} onChange={handleChange} />
+        </div>
+        <div>
+          <h2>Image URL</h2>
+          <hr />
+          <Form.Control name="image" value={formInput.image || ''} onChange={handleChange} />
+        </div>
+        <div>
+          <h2>Answer</h2>
+          <hr />
+          <Form.Control name="answer" value={formInput.answer || ''} onChange={handleChange} />
+        </div>
+      </div>
+      <div className="qd-buttons">
+        <CategoryDropdown selectedCategoryId={questionObj.categoryId} questionId={questionObj.firebaseKey} form={handleChange} />
+        <div className="qd-host-tools">
+          <button type="submit" onClick={handleSubmit}>Save Changes</button>
+          <button type="button" onClick={onUpdate}>Cancel</button>
+        </div>
+      </div>
+    </Form>
   );
 }
+
+QuestionForm.propTypes = {
+  questionObj: PropTypes.shape({
+    question: PropTypes.string,
+    image: PropTypes.string,
+    answer: PropTypes.string,
+    categoryId: PropTypes.string,
+    status: PropTypes.string,
+    timeOpened: PropTypes.string,
+    firebaseKey: PropTypes.string,
+    category: PropTypes.shape({
+      name: PropTypes.string,
+      color: PropTypes.string,
+      firebaseKey: PropTypes.string,
+    }),
+  }),
+  onUpdate: PropTypes.func,
+};
+
+QuestionForm.defaultProps = {
+  questionObj: nullQuestion,
+  onUpdate: null,
+};

--- a/pages/host/question/[id].js
+++ b/pages/host/question/[id].js
@@ -1,19 +1,50 @@
 import { useRouter } from 'next/router';
 import React, { useEffect, useState } from 'react';
-import { getQuestionById } from '../../../api/mergedData';
 import QuestionDetails from '../../../components/QuestionDetails';
+import { useAuth } from '../../../utils/context/authContext';
+import QuestionForm from '../../../components/forms/QuestionForm';
+import { getQuestionById } from '../../../api/mergedData';
 
 export default function ManageQuestion() {
   const router = useRouter();
   const [question, setQuestion] = useState({});
+  const [editing, setEditing] = useState(false);
+  const { user } = useAuth();
+
+  const confirmAccess = (qCheck) => {
+    // If non-host user is attempting to access editing panel for a question
+    // OR question endpoint does not exist
+    // then redirect user to welcome page
+    if (!qCheck.uid || qCheck.uid !== user.uid) {
+      router.push('/');
+    } else {
+      setQuestion(qCheck);
+    }
+  };
+
+  const toggleEdit = () => {
+    setEditing((prev) => !prev);
+  };
+
+  const onUpdate = () => {
+    getQuestionById(router.query.id)
+      .then(setQuestion)
+      .then(() => toggleEdit());
+  };
 
   useEffect(() => {
-    getQuestionById(router.query.id).then(setQuestion);
+    getQuestionById(router.query.id).then(confirmAccess);
   }, []);
 
   return (
-    <div>
-      {question.question && <QuestionDetails questionObj={question} host />}
-    </div>
+    <>
+      {question.question && (
+        editing ? (
+          <QuestionForm questionObj={question} onUpdate={onUpdate} />
+        ) : (
+          <QuestionDetails questionObj={question} host onUpdate={onUpdate} />
+        )
+      )};
+    </>
   );
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -221,12 +221,42 @@ body {
     position: relative;
     height: 90vh;
     text-align: center;
-    button, p {
+    width: 200px;
+    .qd-category, .qd-status {
       border-radius: 5px;
       margin: 5px 0;
-      font-size: 1.2rem;
+      font-size: 1rem;
       padding: 5px 10px;
       width: 100%;
+      min-height: 36px;
+      box-shadow: 0 0 5px black;
+      align-content: center;
+    }
+    .qd-category {
+      display: flex;
+      padding: 0;
+      .qd-category-name {
+        padding: 5px;
+        text-align: center;
+        width: 100%;
+        align-content: center;
+      }
+      .qd-category-toggle {
+        background: none;
+        border: none;
+        border-left: 2px solid black;
+        margin: 0 0 0 auto;
+        padding: 0 10px;
+        font-size: 1rem;
+      }
+      .qd-category-toggle:hover {
+        background:#454949;
+        color: aliceblue;
+        border-radius: 0 5px 5px 0;
+      }
+      .qd-category-toggle:active {
+        box-shadow: inset 0 0 2px black;
+      }
     }
     .qd-host-tools {
       position: absolute;
@@ -235,8 +265,38 @@ body {
       right: 0px;
       button {
         display: block;
+        border-radius: 5px;
+        margin: 5px 0;
+        font-size: 1.2rem;
+        padding: 5px 10px;
+        width: 100%;
       }
     }
   }
-  
+}
+
+.category-menu {
+  position: absolute;
+  background: #454949;
+  color: aliceblue;
+  width: 80%;
+  box-shadow: 0 0 3px black;
+  border-radius: 5px;
+  margin: 0 0 0 20%;
+  cursor: default;
+  z-index: 3;
+  text-align: center;
+  .category-item {
+    display: block;
+    padding: 1px 0;
+    border-radius: 5px;
+    font-size: 0.rem;
+    background: none;
+    border: none;
+    color: aliceblue;
+    width: 100%;
+  }
+  button:hover {
+    background: black;
+  }
 }

--- a/utils/ViewDirector.js
+++ b/utils/ViewDirector.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import { useRouter } from 'next/router';
-// import { useEffect } from 'react';
 import { useAuth } from './context/authContext';
 import Loading from '../components/Loading';
 import Signin from '../components/Signin';
@@ -9,10 +8,6 @@ import NavBarAuth from '../components/NavBarAuth';
 const ViewDirectorBasedOnUserAuthStatus = ({ component: Component, pageProps }) => {
   const { user, userLoading } = useAuth();
   const router = useRouter();
-
-  // useEffect(() => {
-  //   router.push('/');
-  // }, [user]);
 
   // if user state is null, then show loader
   if (userLoading) {


### PR DESCRIPTION
## Description
Added functionality to edit question, broken into CategoryDropdown.js and QuestionForm.js
/host/question/[id] toggles between QuestionDetails and QuestionForm components depending on state of editing

Added checks to prevent non-host users from accessing host tools by url manipulation, redirecting user to home page if trying to access a question they do not have permission to edit.

## Related Issue
#14 

## Motivation and Context
As a host user, I want the ability to edit my questions. This includes changing the question and answer text, accompanied image, and associated category.

Category can be edited directly from the category dropdown on the /host/question/[id] page without having to open the edit form. In the edit form, however, changing the category will not be automatically saved, and only is committed to Firebase when the Save Changes button is pressed.

## How Can This Be Tested?
On the /host/question/[id] page, select a new category from the category dropdown. Refresh page or check firebase to confirm category has been changed.

Click on the 'Edit' button to be taken to question edit form. Make changes to fields and click 'Save Changes' to see changes applied or 'Cancel' to discard changes.

## Screenshots (if appropriate):
![image](https://github.com/alexberka/a-trivial-glance/assets/148516337/55de68e1-37d8-4177-a3ae-a860eb47af9f)
![image](https://github.com/alexberka/a-trivial-glance/assets/148516337/681e3000-94db-47cf-93ab-974d86badf58)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
