### PR TITLE
HOST - Delete Question

### DIFF
--- a/components/QuestionDetails.js
+++ b/components/QuestionDetails.js
@@ -3,7 +3,9 @@ import PropTypes from 'prop-types';
 import { Image } from 'react-bootstrap';
 import CategoryDropdown from './forms/CategoryDropdown';
 
-export default function QuestionDetails({ questionObj, host, onUpdate }) {
+export default function QuestionDetails({
+  questionObj, host, onUpdate, handleDelete,
+}) {
   return (
     <div className="question-details">
       <div className="qd-info">
@@ -45,7 +47,7 @@ export default function QuestionDetails({ questionObj, host, onUpdate }) {
               {questionObj.status === 'closed' && 'Reopen'}
             </button>
             <button type="button" onClick={onUpdate}>Edit</button>
-            <button type="button">Delete</button>
+            <button type="button" onClick={handleDelete}>Delete</button>
           </div>
         )}
       </div>
@@ -69,9 +71,11 @@ QuestionDetails.propTypes = {
   }).isRequired,
   host: PropTypes.bool,
   onUpdate: PropTypes.func,
+  handleDelete: PropTypes.func,
 };
 
 QuestionDetails.defaultProps = {
   host: false,
   onUpdate: null,
+  handleDelete: null,
 };

--- a/pages/host/question/[id].js
+++ b/pages/host/question/[id].js
@@ -4,6 +4,7 @@ import QuestionDetails from '../../../components/QuestionDetails';
 import { useAuth } from '../../../utils/context/authContext';
 import QuestionForm from '../../../components/forms/QuestionForm';
 import { getQuestionById } from '../../../api/mergedData';
+import { deleteQuestion } from '../../../api/questionsData';
 
 export default function ManageQuestion() {
   const router = useRouter();
@@ -32,8 +33,15 @@ export default function ManageQuestion() {
       .then(() => toggleEdit());
   };
 
+  const handleDelete = () => {
+    if (window.confirm('Delete question?')) {
+      deleteQuestion(router.query.id).then(() => router.push('/host/questions'));
+    }
+  };
+
   useEffect(() => {
     getQuestionById(router.query.id).then(confirmAccess);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (
@@ -42,7 +50,7 @@ export default function ManageQuestion() {
         editing ? (
           <QuestionForm questionObj={question} onUpdate={onUpdate} />
         ) : (
-          <QuestionDetails questionObj={question} host onUpdate={onUpdate} />
+          <QuestionDetails questionObj={question} host onUpdate={onUpdate} handleDelete={handleDelete} />
         )
       )};
     </>

--- a/pages/question/[id].js
+++ b/pages/question/[id].js
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 import { useRouter } from 'next/router';
 import React, { useEffect, useState } from 'react';
 import QuestionDetails from '../../components/QuestionDetails';


### PR DESCRIPTION
## Description
Added functionality to /host/question/[id] to delete a question and redirect to /host/questions
handleDelete passed as prop into QuestionDetails component

## Related Issue
#16 

## Motivation and Context
As a host user, I want to be able to delete questions from my database if I don't wish to use them anymore

## How Can This Be Tested?
On any /host/question/[id] page, click the 'Delete' button
Click 'Ok' in the window that opens
Site should direct to /host/questions on delete
Confirm in question display and/or firebase that deleted question has been removed

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
