### PR TITLE
Prevent player from viewing not closed questions

### DIFF
--- a/pages/question/[id].js
+++ b/pages/question/[id].js
@@ -9,7 +9,15 @@ export default function ReviewQuestion() {
   const [question, setQuestion] = useState({});
 
   useEffect(() => {
-    getQuestionById(router.query.id).then(setQuestion);
+    getQuestionById(router.query.id)
+      .then((q) => {
+        if (q.status === 'closed') {
+          setQuestion(q);
+        } else {
+          window.alert('Question Not Available');
+          router.push('/game');
+        }
+      });
   }, []);
 
   return (


### PR DESCRIPTION
## Description
Fixed bug to prevent player from viewing questions that are not closed

## Related Issue
As a host user, I don't want players able to view questions I have not released to them

## Motivation and Context
Players could save firebaseKeys to view the answer

## How Can This Be Tested?
Attempt to navigate to /question/[firebaseKey of open/unused/invalid question]
A window.alert will inform user that the question is not available and redirect back to the game

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
