### PR TITLE
HOST - Read all games

### DIFF
--- a/components/GameCard.js
+++ b/components/GameCard.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Link from 'next/link';
+
+export default function GameCard({ gameObj, host }) {
+  return (
+    // If host is set to true, clicking the card will direct to the game's details page with host tools
+    // Otherwise, clicking will direct player to gameplay view (/game/[id])
+    <Link passHref href={`${host ? '/host' : ''}/game/${gameObj.firebaseKey}`}>
+      <div className="g-card">
+        <div className="g-card-tags">
+          <p className={`g-status status-${gameObj.status}`}>
+            {gameObj.status.toUpperCase()}
+          </p>
+          {/* Include the date of game played if in host view (creates date from ISO String in database) */}
+          {host && (
+            <p className="g-card-infobox">
+              {gameObj.status === 'closed'
+                ? new Date(gameObj.dateLive)
+                  .toDateString()
+                  .split(' ')
+                  .slice(1)
+                  .join(' ')
+                : (
+                  '0 Questions'
+                )}
+            </p>
+          )}
+        </div>
+        <div>
+          <p className="g-card-name">{gameObj.name}</p>
+          <p className="g-card-location">{gameObj.location}</p>
+        </div>
+      </div>
+    </Link>
+  );
+}
+
+GameCard.propTypes = {
+  gameObj: PropTypes.shape({
+    name: PropTypes.string,
+    location: PropTypes.string,
+    status: PropTypes.string,
+    dateLive: PropTypes.string,
+    firebaseKey: PropTypes.string,
+  }).isRequired,
+  host: PropTypes.bool,
+};
+
+GameCard.defaultProps = {
+  host: false,
+};

--- a/components/NavBarAuth.js
+++ b/components/NavBarAuth.js
@@ -16,7 +16,9 @@ export default function NavBarAuth() {
   // Links that appear/disappear dynamically based on path are defined and organized in 'dynamicLinks'
   const dynamicLinks = {
     host: [
-      { path: '/host/questions', text: 'All Questions' },
+      { path: '/host/games', text: 'Games' },
+      { path: '/host/game/new', text: 'New Game' },
+      { path: '/host/questions', text: 'Questions' },
       { path: '/host/question/new', text: 'New Question' },
     ],
     player: [
@@ -51,7 +53,7 @@ export default function NavBarAuth() {
         {router.pathname.includes('host') ? (
           <>
             {/* When in host view, show option to use site as player */}
-            <Link passHref href="/game">
+            <Link passHref href="/games">
               <button type="button">Switch to Player View</button>
             </Link>
             {/* Map through and display dynamic host links other than ones that direct to current path, if any */}
@@ -62,7 +64,8 @@ export default function NavBarAuth() {
                   .filter((link) => link.path !== router.pathname)
                   .map((link) => (
                     <Link passHref href={link.path} key={link.path}>
-                      <button type="button">{link.text}</button>
+                      {/* Close nav menu if a dynamic link is clicked */}
+                      <button type="button" onClick={closeNav}>{link.text}</button>
                     </Link>
                   ))}
               </>
@@ -82,7 +85,8 @@ export default function NavBarAuth() {
                   .filter((link) => link.path !== router.pathname)
                   .map((link) => (
                     <Link passHref href={link.path} key={link.path}>
-                      <button type="button">{link.text}</button>
+                      {/* Close nav menu if a dynamic link is clicked */}
+                      <button type="button" onClick={closeNav}>{link.text}</button>
                     </Link>
                   ))}
               </>

--- a/pages/host/games.js
+++ b/pages/host/games.js
@@ -1,9 +1,35 @@
-import React from 'react';
+/* eslint-disable react-hooks/exhaustive-deps */
+import React, { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { getGamesByHost } from '../../api/gameData';
+import { useAuth } from '../../utils/context/authContext';
+import GameCard from '../../components/GameCard';
 
 export default function HostGames() {
+  const [games, setGames] = useState();
+  const { user } = useAuth();
+
+  useEffect(() => {
+    getGamesByHost(user.uid).then(setGames);
+  }, []);
+
   return (
-    <div>
-      View All Games
-    </div>
+    <>
+      <div className="games-header">
+        <h1 className="page-header">Games</h1>
+        <Link passHref href="/host/game/new">
+          <button type="button" className="">New Game</button>
+        </Link>
+      </div>
+      <div className="games-container">
+        {games ? (
+          games
+            .sort((a, b) => a.name.localeCompare(b.name))
+            .map((game) => <GameCard key={game.firebaseKey} gameObj={game} host />)
+        ) : (
+          <span>Loading Games</span>
+        )}
+      </div>
+    </>
   );
 }

--- a/pages/host/questions.js
+++ b/pages/host/questions.js
@@ -22,7 +22,11 @@ export default function HostQuestions() {
         </Link>
       </div>
       <div className="question-container">
-        {questions.length ? questions.map((q) => <QuestionCard key={q.firebaseKey} questionObj={q} host />) : (<span>Loading Questions</span>)}
+        {questions.length ? (
+          questions.map((q) => <QuestionCard key={q.firebaseKey} questionObj={q} host />)
+        ) : (
+          <span>Loading Questions</span>
+        )}
       </div>
     </>
   );

--- a/pages/index.js
+++ b/pages/index.js
@@ -12,7 +12,7 @@ function Home() {
           <p>Enter As Player</p>
         </div>
         <div>
-          <Link passHref href="/host/questions">
+          <Link passHref href="/host/games">
             <button type="button">HOST</button>
           </Link>
           <p>Enter As Host</p>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -134,6 +134,7 @@ body {
   left: 5vw;
   bottom: 20vh;
   color: aliceblue;
+  text-shadow: 6px 6px black;
   h1, h2, h3 {
     padding: 0;
     margin: 0;
@@ -159,14 +160,65 @@ body {
 .page-header {
   font-size: 10rem;
   color: aliceblue;
+  text-shadow: 8px 8px black;
 }
 
-.question-container {
+.question-container, .games-container {
   display: flex;
   flex-flow: row wrap;
   gap: 10px calc((100% - 1200px)/3);
   justify-content: space-between;
 }
+
+.g-card {
+  background: aliceblue;
+  width: 300px;
+  min-width: 300px;
+  min-height: 3.5rem;
+  height: auto;
+  padding: 5px 0 0 0;
+  margin-bottom: auto;
+  overflow: hidden;
+  border-radius: 5px;
+  box-shadow: inset 0 0 3px black;
+  cursor: pointer;
+  .g-card-name {
+    margin: 0;
+    padding: 0 10px 5px 10px;
+    font-weight: bolder;
+  }
+  .g-card-location {
+    margin: 0;
+    padding: 0 10px 5px 10px;
+    font-style: italic;
+    font-size: 0.7rem;
+  }
+  .g-card-tags {
+    float: right;
+    width: auto;
+    align-content: center;
+    margin: 0 6px;
+    padding: 0;
+    text-align: right;
+  }
+  .g-status {
+    display: inline-block;
+    border-radius: 5px;
+    font-size: 0.7rem;
+    padding: 3px 6px;
+    box-shadow: inset 0 0 3px #454949;
+    width: auto;
+    margin: 0 2px;
+  }
+  .g-card-infobox {
+    font-size: 0.7rem;
+    margin: 4px 2px 0 2px;
+  }
+}
+.g-card:last-of-type {
+  margin-right: auto;
+}
+
 
 .q-card {
   background: aliceblue;
@@ -181,16 +233,36 @@ body {
   transition: max-height 1s;
   border-radius: 5px;
   box-shadow: inset 0 0 3px black;
+  cursor: pointer;
   .q-card-text {
     margin: 0;
     padding: 0 10px 5px 10px;
   }
-  cursor: pointer;
+  .q-card-tags {
+    float: right;
+    width: auto;
+    align-content: center;
+    margin: 0 6px;
+    padding: 0;
+    text-align: right;
+  }
+  .q-category, .q-status {
+    display: inline-block;
+    border-radius: 5px;
+    font-size: 0.7rem;
+    padding: 3px 6px;
+    box-shadow: inset 0 0 3px #454949;
+    width: auto;
+    margin: 0 2px;
+  }
+  .q-timestamp {
+    font-size: 0.7rem;
+    margin: 4px 2px 0 2px;
+  }
 }
 .q-card:last-of-type {
   margin-right: auto;
 }
-
 .q-card:hover {
   max-height: 200px;
 }
@@ -198,38 +270,13 @@ body {
 .status-unused {
   background: #96dbdb;
 }
-
-.status-open {
+.status-open, .status-live {
   background: #82e782;
 }
-
 .status-closed {
   background: #e67c7c;
 }
 
-.q-card-tags {
-  float: right;
-  width: auto;
-  align-content: center;
-  margin: 0 6px;
-  padding: 0;
-  text-align: right;
-}
-
-.q-category, .q-status {
-  display: inline-block;
-  border-radius: 5px;
-  font-size: 0.7rem;
-  padding: 3px 6px;
-  box-shadow: inset 0 0 3px #454949;
-  width: auto;
-  margin: 0 2px;
-}
-
-.q-timestamp {
-  font-size: 0.7rem;
-  margin: 4px 2px 0 2px;
-}
 
 .question-details {
   padding-top: 20px;

--- a/utils/data/games.json
+++ b/utils/data/games.json
@@ -4,7 +4,7 @@
     "name": "Carousel",
     "location": "Senangkhanikhom - Nashville, TN",
     "dateLive": "2023-08-01T06:06:14Z",
-    "isLive": false,
+    "status": "closed",
     "uid": "pLgjt99BhdaBCbCuLWBH6iGDNa23"
   },
   "-Nz_g1yZXlFLWqiAaLbw": {
@@ -12,15 +12,15 @@
     "name": "The Social Network",
     "location": "Mascouche",
     "dateLive": "never",
-    "isLive": false,
-    "uid": null
+    "status": "unused",
+    "uid": "iZUQy63CVYWrhIyGJl4WRlaPATJ3"
   },
   "-Nz_g1y_NMVx8lvkkqve": {
     "firebaseKey": "-Nz_g1y_NMVx8lvkkqve",
-    "name": "Sprung",
+    "name": "Gregorian Chant",
     "location": "Jijia, Albesti",
     "dateLive": "never",
-    "isLive": false,
+    "status": "unused",
     "uid": "pLgjt99BhdaBCbCuLWBH6iGDNa23"
   },
   "-Nz_g1yaNdIQgwZn6btx": {
@@ -28,7 +28,7 @@
     "name": "Blade II",
     "location": "Şirvan",
     "dateLive": "2024-06-04T20:00:54Z",
-    "isLive": true,
+    "status": "open",
     "uid": "pLgjt99BhdaBCbCuLWBH6iGDNa23"
   },
   "-Nz_g1ybuP6g6kIsd6dY": {
@@ -36,7 +36,7 @@
     "name": "Abbott and Costello Meet Dr. Jekyll and Mr. Hyde",
     "location": "Kadugedong",
     "dateLive": "2024-06-04T12:40:30Z",
-    "isLive": true,
+    "status": "open",
     "uid": "iZUQy63CVYWrhIyGJl4WRlaPATJ3"
   }
 }


### PR DESCRIPTION
## Description
Created GameCard.js to display games and their information on /host/games

Redirected 'HOST' button from welcome page to land on /host/games

## Related Issue
#7 

## Motivation and Context
As a host user, I want to be able to view all of the games I have created along with their status. This allows me to easily navigate between my games and further manage their status, info, and associated questions.

## How Can This Be Tested?
From Welcome Page '/', select 'HOST' to navigate to '/host/games'
All of your games should appear on this page
Click on a game to navigate to specific game details at '/host/game/[id]' (undeveloped)
'Live' and 'Unused' games show number of questions added to that game (requires many-to-many adaptation of games-questions relationship)
'Closed' game displays date of game use.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
