### PR TITLE
MTM - Add gameQuestion many-to-many

### DIFF
--- a/api/gameQuestionsData.js
+++ b/api/gameQuestionsData.js
@@ -1,0 +1,99 @@
+import { clientCredentials } from '../utils/client';
+
+const ENDPOINT = clientCredentials.databaseURL;
+
+const getGameQuestionsByHost = (uid) => new Promise((resolve, reject) => {
+  fetch(`${ENDPOINT}/gameQuestions.json?orderBy="uid"&equalTo="${uid}"`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application.json',
+    },
+  })
+    .then((response) => response.json())
+    .then((data) => resolve(data ? Object.values(data) : []))
+    .catch(reject);
+});
+
+const getGameQuestionsByGame = (gameId) => new Promise((resolve, reject) => {
+  fetch(`${ENDPOINT}/gameQuestions.json?orderBy="gameId"&equalTo="${gameId}"`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application.json',
+    },
+  })
+    .then((response) => response.json())
+    .then((data) => resolve(data ? Object.values(data) : []))
+    .catch(reject);
+});
+
+const getGameQuestionsByQuestion = (questionId) => new Promise((resolve, reject) => {
+  fetch(`${ENDPOINT}/gameQuestions.json?orderBy="questionId"&equalTo="${questionId}"`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application.json',
+    },
+  })
+    .then((response) => response.json())
+    .then((data) => resolve(data ? Object.values(data) : []))
+    .catch(reject);
+});
+
+const getGameQuestionById = (firebaseKey) => new Promise((resolve, reject) => {
+  fetch(`${ENDPOINT}/gameQuestions/${firebaseKey}.json`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application.json',
+    },
+  })
+    .then((response) => response.json())
+    .then(resolve)
+    .catch(reject);
+});
+
+const createGameQuestion = (payload) => new Promise((resolve, reject) => {
+  fetch(`${ENDPOINT}/gameQuestions.json`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application.json',
+    },
+    body: JSON.stringify(payload),
+  })
+    .then((response) => response.json())
+    .then(resolve)
+    .catch(reject);
+});
+
+const updateGameQuestion = (payload) => new Promise((resolve, reject) => {
+  fetch(`${ENDPOINT}/gameQuestions/${payload.firebaseKey}.json`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application.json',
+    },
+    body: JSON.stringify(payload),
+  })
+    .then((response) => response.json())
+    .then(resolve)
+    .catch(reject);
+});
+
+const deleteGameQuestion = (firebaseKey) => new Promise((resolve, reject) => {
+  fetch(`${ENDPOINT}/gameQuestions/${firebaseKey}.json`, {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application.json',
+    },
+  })
+    .then((response) => response.json())
+    .then(resolve)
+    .catch(reject);
+});
+
+export {
+  getGameQuestionsByHost,
+  getGameQuestionsByGame,
+  getGameQuestionsByQuestion,
+  getGameQuestionById,
+  createGameQuestion,
+  updateGameQuestion,
+  deleteGameQuestion,
+};

--- a/api/gameQuestionsData.js
+++ b/api/gameQuestionsData.js
@@ -2,18 +2,6 @@ import { clientCredentials } from '../utils/client';
 
 const ENDPOINT = clientCredentials.databaseURL;
 
-const getGameQuestionsByHost = (uid) => new Promise((resolve, reject) => {
-  fetch(`${ENDPOINT}/gameQuestions.json?orderBy="uid"&equalTo="${uid}"`, {
-    method: 'GET',
-    headers: {
-      'Content-Type': 'application.json',
-    },
-  })
-    .then((response) => response.json())
-    .then((data) => resolve(data ? Object.values(data) : []))
-    .catch(reject);
-});
-
 const getGameQuestionsByGame = (gameId) => new Promise((resolve, reject) => {
   fetch(`${ENDPOINT}/gameQuestions.json?orderBy="gameId"&equalTo="${gameId}"`, {
     method: 'GET',
@@ -89,7 +77,6 @@ const deleteGameQuestion = (firebaseKey) => new Promise((resolve, reject) => {
 });
 
 export {
-  getGameQuestionsByHost,
   getGameQuestionsByGame,
   getGameQuestionsByQuestion,
   getGameQuestionById,

--- a/components/GameDisplay.js
+++ b/components/GameDisplay.js
@@ -59,12 +59,15 @@ GameDisplay.propTypes = {
   questions: PropTypes.arrayOf(PropTypes.shape({
     question: PropTypes.string,
     answer: PropTypes.string,
-    status: PropTypes.string,
-    timeOpened: PropTypes.string,
+    lastUsed: PropTypes.string,
     firebaseKey: PropTypes.string,
     category: PropTypes.shape({
       name: PropTypes.string,
       color: PropTypes.string,
+    }),
+    gameQuestion: PropTypes.shape({
+      status: PropTypes.string,
+      timeOpened: PropTypes.string,
     }),
   })).isRequired,
 };

--- a/components/NavBarAuth.js
+++ b/components/NavBarAuth.js
@@ -53,7 +53,7 @@ export default function NavBarAuth() {
         {router.pathname.includes('host') ? (
           <>
             {/* When in host view, show option to use site as player */}
-            <Link passHref href="/games">
+            <Link passHref href="/game">
               <button type="button">Switch to Player View</button>
             </Link>
             {/* Map through and display dynamic host links other than ones that direct to current path, if any */}
@@ -74,7 +74,7 @@ export default function NavBarAuth() {
         ) : (
           <>
             {/* When in player view, show option to use site as host */}
-            <Link passHref href="/host/questions">
+            <Link passHref href="/host/games">
               <button type="button">Switch to Host View</button>
             </Link>
             {/* Map through and display dynamic player links other than ones that direct to current path, if any */}

--- a/components/QuestionCard.js
+++ b/components/QuestionCard.js
@@ -14,18 +14,21 @@ export default function QuestionCard({ questionObj, host }) {
           <p className="q-category" style={{ background: `${questionObj.category.color}` }}>
             {questionObj.category.name.toUpperCase()}
           </p>
-          <p className={`q-status status-${questionObj.status}`}>
-            {questionObj.status.toUpperCase()}
-          </p>
+          {questionObj.gameQuestion && (
+            <p className={`q-status status-${questionObj.gameQuestion.status}`}>
+              {questionObj.gameQuestion.status.toUpperCase()}
+            </p>
+          )}
           {/* Include the date of last usage if in host view (creates date from ISO String in database) */}
           {host && (
             <p className="q-timestamp">
-              {questionObj.status === 'closed' && (
-                `Last Used: ${new Date(questionObj.timeOpened)
+              {questionObj.lastUsed !== 'never'
+                ? `Last Used: ${new Date(questionObj.lastUsed)
                   .toDateString()
                   .split(' ')
                   .slice(1)
-                  .join(' ')}`)}
+                  .join(' ')}`
+                : 'Last Used: Never'}
             </p>
           )}
         </div>
@@ -41,12 +44,15 @@ QuestionCard.propTypes = {
   questionObj: PropTypes.shape({
     question: PropTypes.string,
     answer: PropTypes.string,
-    status: PropTypes.string,
-    timeOpened: PropTypes.string,
+    lastUsed: PropTypes.string,
     firebaseKey: PropTypes.string,
     category: PropTypes.shape({
       name: PropTypes.string,
       color: PropTypes.string,
+    }),
+    gameQuestion: PropTypes.shape({
+      status: PropTypes.string,
+      timeOpened: PropTypes.string,
     }),
   }).isRequired,
   host: PropTypes.bool,

--- a/components/QuestionDetails.js
+++ b/components/QuestionDetails.js
@@ -42,9 +42,9 @@ export default function QuestionDetails({
   const handleStatus = (e) => {
     // NOTE: The 'Reset' button has a value of 'reset', other buttons have an empty string. The trigger will then
     // default to the current status of the question.
-    const trigger = e.target.value || questionObj.status;
+    const trigger = e.target.value || questionObj.gameQuestion.status;
     // Initialize payload with question's Firebase key
-    const payload = { firebaseKey: questionObj.firebaseKey };
+    const payload = { firebaseKey: questionObj.gameQuestion.firebaseKey };
     switch (trigger) {
       case 'reset':
         // If the 'Reset' button was clicked, confirm with user that this is the desired action.
@@ -109,9 +109,11 @@ export default function QuestionDetails({
             {questionObj.category.name.toUpperCase()}
           </p>
         )}
-        <p className={`qd-status status-${questionObj.status}`}>
-          {questionObj.status.toUpperCase()}
-        </p>
+        {questionObj.gameQuestion && (
+          <p className={`qd-status status-${questionObj.gameQuestion.status}`}>
+            {questionObj.gameQuestion.status.toUpperCase()}
+          </p>
+        )}
         {/* If in player view, include button to return to current game */}
         {!host
         && (
@@ -125,23 +127,34 @@ export default function QuestionDetails({
         {host
         && (
         <p className="qd-timestamp">
-          {questionObj.status === 'closed' && (
-            `Last Used: ${new Date(questionObj.timeOpened).toDateString()}`)}
+          {questionObj.lastUsed !== 'never'
+            ? `Last Used: ${new Date(questionObj.lastUsed)
+              .toDateString()
+              .split(' ')
+              .join(' ')}`
+            : 'Last Used: Never'}
         </p>
         )}
         {/* If in host view, display status, edit, and delete host tools */}
         {host && (
           <div className="qd-host-tools">
-            {questionObj.status === 'closed' && (<button type="button" onClick={handleStatus} value="reset">Reset</button>)}
-            <button type="button" onClick={handleStatus}>
-              {questionObj.status === 'unused' && 'Open'}
-              {questionObj.status === 'open' && 'Close'}
-              {questionObj.status === 'closed' && 'Reopen'}
-            </button>
-            {/* On edit, defer to onUpdate behavior defined by prop */}
-            <button type="button" onClick={onUpdate}>Edit</button>
-            {/* On delete, defer to handleDelete behavior defined by prop */}
-            <button type="button" onClick={handleDelete}>Delete</button>
+            {questionObj.gameQuestion ? (
+              <>
+                {questionObj.gameQuestion.status === 'closed' && (
+                  <button type="button" onClick={handleStatus} value="reset">Reset</button>
+                )}
+                <button type="button" onClick={handleStatus}>
+                  {questionObj.gameQuestion.status === 'unused' && 'Open'}
+                  {questionObj.gameQuestion.status === 'open' && 'Close'}
+                  {questionObj.gameQuestion.status === 'closed' && 'Reopen'}
+                </button>
+              </>
+            ) : (
+              <>
+                <button type="button" onClick={onUpdate}>Edit</button>
+                <button type="button" onClick={handleDelete}>Delete</button>
+              </>
+            )}
           </div>
         )}
       </div>
@@ -154,12 +167,16 @@ QuestionDetails.propTypes = {
     question: PropTypes.string,
     image: PropTypes.string,
     answer: PropTypes.string,
-    status: PropTypes.string,
-    timeOpened: PropTypes.string,
+    lastUsed: PropTypes.string,
     firebaseKey: PropTypes.string,
     category: PropTypes.shape({
       name: PropTypes.string,
       color: PropTypes.string,
+      firebaseKey: PropTypes.string,
+    }),
+    gameQuestion: PropTypes.shape({
+      status: PropTypes.string,
+      timeOpened: PropTypes.string,
       firebaseKey: PropTypes.string,
     }),
   }).isRequired,

--- a/components/forms/QuestionForm.js
+++ b/components/forms/QuestionForm.js
@@ -11,9 +11,8 @@ const nullQuestion = {
   question: '',
   image: '',
   answer: '',
-  status: 'unused',
-  timeOpened: 'never',
   categoryId: '',
+  lastUsed: 'never',
 };
 
 // 'questionObj' contains information to populate form on edit
@@ -96,8 +95,6 @@ QuestionForm.propTypes = {
     image: PropTypes.string,
     answer: PropTypes.string,
     categoryId: PropTypes.string,
-    status: PropTypes.string,
-    timeOpened: PropTypes.string,
     firebaseKey: PropTypes.string,
     category: PropTypes.shape({
       name: PropTypes.string,

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -224,7 +224,7 @@ body {
   background: aliceblue;
   width: 300px;
   min-width: 300px;
-  min-height: 3.5rem;
+  min-height: 58px;
   height: auto;
   padding: 5px 0 0 0;
   margin-bottom: auto;

--- a/utils/data/gameQuestions.json
+++ b/utils/data/gameQuestions.json
@@ -1,0 +1,82 @@
+{
+  "-NzfOFCg-z_4efyGAw6g": {
+    "firebaseKey": "-NzfOFCg-z_4efyGAw6g",
+    "questionId": "-NykLdhS-oDANusmMKQO",
+    "gameId": "-Nz_g1yYFuI9itxthqNO",
+    "status": "closed",
+    "timeOpened": "2023-08-01T06:12:20Z",
+    "queue": 2
+  },
+  "-NzfOFChAQgV_8bYX6I5": {
+    "firebaseKey": "-NzfOFChAQgV_8bYX6I5",
+    "questionId": "-NykLdhUZVmXne4J8Iqr",
+    "gameId": "-Nz_g1yZXlFLWqiAaLbw",
+    "status": "unused",
+    "timeOpened": "never",
+    "queue": 0
+  },
+  "-NzfOFCikZAYJG3zhlZk": {
+    "firebaseKey": "-NzfOFCikZAYJG3zhlZk",
+    "questionId": "-NykLdhVSBaeMrQu4MtQ",
+    "gameId": "-Nz_g1yaNdIQgwZn6btx",
+    "status": "open",
+    "timeOpened": "2024-06-04T20:16:54Z",
+    "queue": 4
+  },
+  "-NzfOFCko9tmDMqbnacT": {
+    "firebaseKey": "-NzfOFCko9tmDMqbnacT",
+    "questionId": "-NykLdhWc1nxRnp4dbKp",
+    "gameId": "-Nz_g1yYFuI9itxthqNO",
+    "status": "released",
+    "timeOpened": "2023-08-01T06:06:20Z",
+    "queue": 1
+  },
+  "-NzfOFCl5kYnv9043q8z": {
+    "firebaseKey": "-NzfOFCl5kYnv9043q8z",
+    "questionId": "-NykLdhLh7qJcaOgg17M",
+    "gameId": "-Nz_g1y_NMVx8lvkkqve",
+    "status": "unused",
+    "timeOpened": "never",
+    "queue": 0
+  },
+  "-NzfOFCmZp_X0-rVr7lB": {
+    "firebaseKey": "-NzfOFCmZp_X0-rVr7lB",
+    "questionId": "-NykLdhS-oDANusmMKQO",
+    "gameId": "-Nz_g1yaNdIQgwZn6btx",
+    "status": "released",
+    "timeOpened": "2024-06-04T20:08:54Z",
+    "queue": 2
+  },
+  "-NzfOFCnpWUTxmYHVnRG": {
+    "firebaseKey": "-NzfOFCnpWUTxmYHVnRG",
+    "questionId": "-NykLdhTUX_mbdZpUkGs",
+    "gameId": "-Nz_g1yaNdIQgwZn6btx",
+    "status": "unused",
+    "timeOpened": "never",
+    "queue": 5
+  },
+  "-NzfOFCpg4_M8vHaIyMH": {
+    "firebaseKey": "-NzfOFCpg4_M8vHaIyMH",
+    "questionId": "-NykLdhPIBq71_IkT9oJ",
+    "gameId": "-Nz_g1yaNdIQgwZn6btx",
+    "status": "closed",
+    "timeOpened": "2024-06-04T20:12:54Z",
+    "queue": 3
+  },
+  "-NzfOFCqKUR49DpmQxtQ": {
+    "firebaseKey": "-NzfOFCqKUR49DpmQxtQ",
+    "questionId": "-NykLdhO9k735G1WcIsd",
+    "gameId": "-Nz_g1yaNdIQgwZn6btx",
+    "status": "unused",
+    "timeOpened": "never",
+    "queue": 0
+  },
+  "-NzfOFCrwsTT2xZ5p61a": {
+    "firebaseKey": "-NzfOFCrwsTT2xZ5p61a",
+    "questionId": "-NykLdhQOLRDEENVrqIF",
+    "gameId": "-Nz_g1yaNdIQgwZn6btx",
+    "status": "released",
+    "timeOpened": "2024-06-04T20:03:54Z",
+    "queue": 1
+  }
+}

--- a/utils/data/games.json
+++ b/utils/data/games.json
@@ -28,7 +28,7 @@
     "name": "Blade II",
     "location": "Şirvan",
     "dateLive": "2024-06-04T20:00:54Z",
-    "status": "open",
+    "status": "live",
     "uid": "pLgjt99BhdaBCbCuLWBH6iGDNa23"
   },
   "-Nz_g1ybuP6g6kIsd6dY": {
@@ -36,7 +36,7 @@
     "name": "Abbott and Costello Meet Dr. Jekyll and Mr. Hyde",
     "location": "Kadugedong",
     "dateLive": "2024-06-04T12:40:30Z",
-    "status": "open",
+    "status": "live",
     "uid": "iZUQy63CVYWrhIyGJl4WRlaPATJ3"
   }
 }

--- a/utils/data/questions.json
+++ b/utils/data/questions.json
@@ -4,8 +4,7 @@
     "categoryId": "-NykGVDAR7zmcnmudhPk",
     "question": "In 'The Lion King', what was the name of Simba's mother?",
     "answer": "Sarabi",
-    "status": "unused",
-    "timeOpened": "never",
+    "lastUsed": "never",
     "uid": "pLgjt99BhdaBCbCuLWBH6iGDNa23"
   },
   "-NykLdhNqhfDn7qChqDg": {
@@ -13,8 +12,7 @@
     "categoryId": "-NykGVDAR7zmcnmudhPl",
     "question": "On 'Friends', what kind of animal was Ross's pet Marcel?",
     "answer": "Capuchin Monkey",
-    "status": "open",
-    "timeOpened": "2024-05-24T02:12:35Z",
+    "lastUsed": "never",
     "uid": "pLgjt99BhdaBCbCuLWBH6iGDNa23"
   },
   "-NykLdhO9k735G1WcIsd": {
@@ -22,8 +20,7 @@
     "categoryId": "-NykGVDB5KbUqw_C5sVe",
     "question": "What rock band has won the most Grammy awards of any group in history with 22?",
     "answer": "U2",
-    "status": "closed",
-    "timeOpened": "2024-05-24T02:46:20Z",
+    "lastUsed": "never",
     "uid": "pLgjt99BhdaBCbCuLWBH6iGDNa23"
   },
   "-NykLdhPIBq71_IkT9oJ": {
@@ -31,8 +28,7 @@
     "categoryId": "-NykGVDB5KbUqw_C5sVf",
     "question": "Name the most recent NFL team to finish a season winless",
     "answer": "Cleveland Browns (2017)",
-    "status": "closed",
-    "timeOpened": "2024-05-23T10:29:20Z",
+    "lastUsed": "2024-06-04T20:12:54Z",
     "uid": "pLgjt99BhdaBCbCuLWBH6iGDNa23"
   },
   "-NykLdhQOLRDEENVrqIF": {
@@ -40,8 +36,7 @@
     "categoryId": "-NykGVDCGjGFW6_jDvQJ",
     "question": "Hyperhidrosis is the medical term for what condition?",
     "answer": "Excessive sweating",
-    "status": "closed",
-    "timeOpened": "2024-05-24T01:18:23Z",
+    "lastUsed": "2024-06-04T20:03:54Z",
     "uid": "pLgjt99BhdaBCbCuLWBH6iGDNa23"
   },
   "-NykLdhS-oDANusmMKQO": {
@@ -49,8 +44,7 @@
     "categoryId": "-NykGVDCGjGFW6_jDvQK",
     "question": "Near which major US city do the Mississippi and Missouri Rivers meet?",
     "answer": "St. Louis",
-    "status": "unused",
-    "timeOpened": "never",
+    "lastUsed": "2024-06-04T20:08:54Z",
     "uid": "pLgjt99BhdaBCbCuLWBH6iGDNa23"
   },
   "-NykLdhTUX_mbdZpUkGs": {
@@ -58,8 +52,7 @@
     "categoryId": "-NykGVDDI2mAecsXbJ1S",
     "question": "Within three years either way, how old was Mary Shelley when she started writing 'Frankenstein'?",
     "answer": "18",
-    "status": "closed",
-    "timeOpened": "2024-05-23T15:16:12Z",
+    "lastUsed": "never",
     "uid": "pLgjt99BhdaBCbCuLWBH6iGDNa23"
   },
   "-NykLdhUZVmXne4J8Iqr": {
@@ -67,8 +60,7 @@
     "categoryId": "-NykGVDDI2mAecsXbJ1T",
     "question": "What is the highest ranking suit in the card game Bridge?",
     "answer": "Spades",
-    "status": "unused",
-    "timeOpened": "never",
+    "lastUsed": "never",
     "uid": "iZUQy63CVYWrhIyGJl4WRlaPATJ3"
   },
   "-NykLdhVSBaeMrQu4MtQ": {
@@ -77,8 +69,7 @@
     "question": "In spite of 17 pregnancies, who became the final British monarch from the House of Stuart after dying without an heir?",
     "image": "https://upload.wikimedia.org/wikipedia/commons/e/e9/Dahl%2C_Michael_-_Queen_Anne_-_NPG_6187.jpg",
     "answer": "Anne, Queen of Great Britain",
-    "status": "unused",
-    "timeOpened": "never",
+    "lastUsed": "2024-06-04T20:16:54Z",
     "uid": "pLgjt99BhdaBCbCuLWBH6iGDNa23"
   },
   "-NykLdhWc1nxRnp4dbKp": {
@@ -86,8 +77,7 @@
     "categoryId": "-NykGVDEjLDZuu-5qmxY",
     "question": "What non-alcoholic drink is traditionally made using grenadine with lemon-lime soda or ginger ale?",
     "answer": "Shirley Temple",
-    "status": "closed",
-    "timeOpened": "2024-05-24T09:54:54Z",
+    "lastUsed": "2023-08-01T06:06:20Z",
     "uid": "pLgjt99BhdaBCbCuLWBH6iGDNa23"
   }
 }


### PR DESCRIPTION
## Description
Created, seeded gameQuestion entities
Removed status, timeOpened from question entities, replaced with lastUsed
Add API calls for getGameQuestionBy{Game/Question/Id}, {create/update/delete}GameQuestion
Edited necessary components to reflect change in data structure of question entities
Removed some information from question displays that will be again present with further implementation of gameQuestions

## Related Issue
#43 

## Motivation and Context
As a host user, I want to be able to link questions to multiple games, and manipulate the status of each instance of those games without impacting the overall question.

## How Can This Be Tested?
Test new gameQuestion endpoints in Postman
Navigate site, attemtp question CRUD, and check for errors thrown in devtools

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
