### PR TITLE
Adapted GameDisplay for host game management

### DIFF
--- a/api/mergedData.js
+++ b/api/mergedData.js
@@ -1,4 +1,6 @@
 import { getCategories, getCategoryById } from './categoriesData';
+import { getGameById } from './gameData';
+import { getGameQuestionsByGame } from './gameQuestionsData';
 import { getQuestionByIdNoCat, getQuestionsByHostNoCats, getQuestionsNoCats } from './questionsData';
 
 const getQuestions = async () => {
@@ -21,8 +23,31 @@ const getQuestionById = async (firebaseKey) => {
   return { ...question, category };
 };
 
+// Retrieves a game's questions with status information
+const getGameQuestions = async (gameId) => {
+  const gameQuestions = await getGameQuestionsByGame(gameId);
+  const promisedQs = gameQuestions.map((q) => getQuestionById(q.questionId));
+  const realQs = await Promise.all(promisedQs);
+  return gameQuestions.map((gq, index) => ({
+    ...realQs[index],
+    status: gq.status,
+    timeOpened: gq.timeOpened,
+    queue: gq.queue,
+    gameQuestionId: gq.firebaseKey,
+  }));
+};
+
+// Retrieves a game with its gameQuestions(+associated question & category data)
+const getFullGameData = async (gameId) => {
+  const gameInfo = await getGameById(gameId);
+  const questions = await getGameQuestions(gameId);
+  return { ...gameInfo, questions };
+};
+
 export {
   getQuestions,
   getQuestionsByHost,
   getQuestionById,
+  getGameQuestions,
+  getFullGameData,
 };

--- a/components/GameDisplay.js
+++ b/components/GameDisplay.js
@@ -4,70 +4,128 @@ import { Image } from 'react-bootstrap';
 import QuestionCard from './QuestionCard';
 
 // 'questions' contains questions for game with attached category objects
-export default function GameDisplay({ questions }) {
+export default function GameDisplay({ game, host }) {
   const display = {
+    unusedQ: game.questions.filter((q) => q.status === 'unused'),
     // Game's open question (should only be one, but will grab first in array regardless)
-    openQ: questions.filter((q) => q.status === 'open')[0],
+    openQ: game.questions.filter((q) => q.status === 'open')[0],
     // Game's closed questions (will be displayed on '/game' in reverse order from when used)
-    closedQ: questions
+    closedQ: game.questions
       .filter((q) => q.status === 'closed')
+      .sort((a, b) => b.timeOpened.localeCompare(a.timeOpened)),
+    releasedQ: game.questions
+      .filter((q) => q.status === 'released')
       .sort((a, b) => b.timeOpened.localeCompare(a.timeOpened)),
   };
 
   return (
     <div className="game-display">
-      <div className="gd-open">
-        {/* Display open question, if any */}
-        {display.openQ && (
-          <>
-            <div className="gd-open-tags">
-              <p className="gd-open-category" style={{ background: `${display.openQ.category.color}` }}>
-                {display.openQ.category.name.toUpperCase()}
-              </p>
-              <p className={`gd-open-status status-${display.openQ.status}`}>
-                {display.openQ.status.toUpperCase()}
-              </p>
+      <div className="gd-header">
+        <div className="gd-title-box">
+          <span>
+            <h1>{game.name}</h1>
+            {game.status === 'live' && (<span className="status-live gd-game-live">LIVE</span>)}
+          </span>
+          <h2>{game.location}</h2>
+        </div>
+        {host && (
+          <div className="gd-host-tools">
+            <div>
+              <button type="button">Add Question</button>
+              <button type="button">{game.status === 'live' ? 'Close Game' : 'Go Live'}</button>
             </div>
-            {/* Calculate question number based on number of closed questions */}
-            <h2>
-              Question #{display.closedQ.length + 1}
-            </h2>
-            <hr />
-            <p className="gd-open-question">
-              {display.openQ.question}
-            </p>
-            {display.openQ.image && (<Image className="gd-image" src={display.openQ.image} />)}
-          </>
+            <div>
+              <button type="button">Edit</button>
+              <button type="button">Delete</button>
+            </div>
+          </div>
         )}
       </div>
-      <div className="gd-closed">
-        {/* Display closed question(s), if any */}
-        {display.closedQ && (
-          <>
-            <h3>Past Questions</h3>
-            <div className="gd-closed-container">
-              {display.closedQ.map((q) => (<QuestionCard key={q.firebaseKey} questionObj={q} />))}
+      <div className="gd-container">
+        {host && (
+          <div className="gd-unused">
+            <h3>Unused</h3>
+            <div className="gd-card-container">
+              {display.unusedQ.map((q) => (<QuestionCard key={q.firebaseKey} questionObj={q} host />))}
             </div>
-          </>
+          </div>
         )}
+        {host ? (
+          <div className="gd-open-host">
+            <h3>Open</h3>
+            <div className="gd-card-container">
+              {display.openQ && (<QuestionCard questionObj={display.openQ} host />)}
+            </div>
+          </div>
+        ) : (
+          <div className="gd-open-player">
+            {/* Display open question, if any */}
+            {display.openQ && (
+            <>
+              <div className="gd-open-tags">
+                <p className="gd-open-category" style={{ background: `${display.openQ.category.color}` }}>
+                  {display.openQ.category.name.toUpperCase()}
+                </p>
+                <p className={`gd-open-status status-${display.openQ.status}`}>
+                  {display.openQ.status.toUpperCase()}
+                </p>
+              </div>
+              {/* Calculate question number based on number of closed questions */}
+              <h2>
+                Question #{display.closedQ.length + 1}
+              </h2>
+              <hr />
+              <p className="gd-open-question">
+                {display.openQ.question}
+              </p>
+              {display.openQ.image && (<Image className="gd-image" src={display.openQ.image} />)}
+            </>
+            )}
+          </div>
+        )}
+        {host && (
+          <div className="gd-closed">
+            <h3>Closed</h3>
+            <div className="gd-card-container">
+              {display.closedQ.map((q) => (<QuestionCard key={q.firebaseKey} questionObj={q} host />))}
+            </div>
+          </div>
+        )}
+        <div className="gd-released">
+          {/* Display closed question(s), if any */}
+          <h3>{host ? 'Released' : 'Past Questions'}</h3>
+          <div className="gd-card-container">
+            {display.releasedQ.map((q) => (<QuestionCard key={q.firebaseKey} questionObj={q} host />))}
+          </div>
+        </div>
       </div>
     </div>
   );
 }
 
 GameDisplay.propTypes = {
-  questions: PropTypes.arrayOf(PropTypes.shape({
-    question: PropTypes.string,
-    answer: PropTypes.string,
-    lastUsed: PropTypes.string,
-    firebaseKey: PropTypes.string,
-    category: PropTypes.shape({
-      name: PropTypes.string,
-      color: PropTypes.string,
-    }),
-    gameQuestion: PropTypes.shape({
+  game: PropTypes.shape({
+    name: PropTypes.string,
+    location: PropTypes.string,
+    status: PropTypes.string,
+    questions: PropTypes.arrayOf(PropTypes.shape({
+      question: PropTypes.string,
+      answer: PropTypes.string,
+      lastUsed: PropTypes.string,
+      firebaseKey: PropTypes.string,
+      gameQuestionId: PropTypes.string,
+      queue: PropTypes.number,
       status: PropTypes.string,
       timeOpened: PropTypes.string,
-    }),
-  })).isRequired,
+      category: PropTypes.shape({
+        name: PropTypes.string,
+        color: PropTypes.string,
+      }),
+    })),
+  }).isRequired,
+  host: PropTypes.bool,
+};
+
+GameDisplay.defaultProps = {
+  host: false,
 };

--- a/components/QuestionCard.js
+++ b/components/QuestionCard.js
@@ -14,9 +14,9 @@ export default function QuestionCard({ questionObj, host }) {
           <p className="q-category" style={{ background: `${questionObj.category.color}` }}>
             {questionObj.category.name.toUpperCase()}
           </p>
-          {questionObj.gameQuestion && (
-            <p className={`q-status status-${questionObj.gameQuestion.status}`}>
-              {questionObj.gameQuestion.status.toUpperCase()}
+          {questionObj.gameQuestionId && (
+            <p className={`q-status status-${questionObj.status}`}>
+              {questionObj.status.toUpperCase()}
             </p>
           )}
           {/* Include the date of last usage if in host view (creates date from ISO String in database) */}
@@ -46,13 +46,13 @@ QuestionCard.propTypes = {
     answer: PropTypes.string,
     lastUsed: PropTypes.string,
     firebaseKey: PropTypes.string,
+    gameQuestionId: PropTypes.string,
+    queue: PropTypes.number,
+    status: PropTypes.string,
+    timeOpened: PropTypes.string,
     category: PropTypes.shape({
       name: PropTypes.string,
       color: PropTypes.string,
-    }),
-    gameQuestion: PropTypes.shape({
-      status: PropTypes.string,
-      timeOpened: PropTypes.string,
     }),
   }).isRequired,
   host: PropTypes.bool,

--- a/pages/game.js
+++ b/pages/game.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import GameDisplay from '../components/GameDisplay';
+// import GameDisplay from '../components/GameDisplay';
 import { getQuestions } from '../api/mergedData';
 
 export default function PlayerGame() {
@@ -20,7 +20,7 @@ export default function PlayerGame() {
 
   return (
     <div>
-      {questions && (<GameDisplay questions={questions} />)}
+      {/* {questions && (<GameDisplay questions={questions} />)} */}
     </div>
   );
 }

--- a/pages/host/game/[id].js
+++ b/pages/host/game/[id].js
@@ -1,9 +1,20 @@
-import React from 'react';
+/* eslint-disable react-hooks/exhaustive-deps */
+import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import GameDisplay from '../../../components/GameDisplay';
+import { getFullGameData } from '../../../api/mergedData';
 
 export default function ManageGame() {
+  const [gameData, setGameData] = useState();
+  const router = useRouter();
+
+  useEffect(() => {
+    getFullGameData(router.query.id).then(setGameData);
+  }, []);
+
   return (
     <div>
-      View/Manage This Game
+      {gameData && (<GameDisplay game={gameData} host />)}
     </div>
   );
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,4 +1,5 @@
 @import 'bootstrap/dist/css/bootstrap.css';
+@import url('https://fonts.googleapis.com/css2?family=Tiny5&display=swap');
 
 html,
 body {
@@ -222,6 +223,7 @@ body {
 
 .q-card {
   background: aliceblue;
+  color: black;
   width: 300px;
   min-width: 300px;
   min-height: 58px;
@@ -413,74 +415,149 @@ body {
 }
 
 .game-display {
-  display: flex;
   color: aliceblue;
-  .gd-open {
-    width: 75%;
-    margin: 10px 0 0 0;
-    padding: 0 10px;
-    border-left: 2px solid aliceblue;
-    h2 {
-      width: 100%;
-      text-align: center;
+  width: 100%;
+  .gd-header {
+    position: relative;
+    width: 100%;
+    text-align: center;
+    margin-top: 10px;
+    display: flex;
+    gap: 40px;
+    align-items: last baseline;
+    .gd-title-box {
+      flex: 1;
+      max-width: calc(100% - 300px - 40px);
+      h1, h2 {
+        text-shadow: 4px 4px black;
+      }
+      h1 {
+        font-size: 4rem;
+        margin: 0;
+        display: inline-block;
+      }
+      h2 {
+        font-size: 2rem;
+        font-style: italic;
+      }
+      span {
+        position: relative;
+      }
+      .gd-game-live {
+        position: absolute;
+        display: inline-block;
+        top: -2.1rem;
+        right: -90px;
+        font-size: 1.3rem;
+        color: black;
+        display: inline-block;
+        border-radius: 5px;
+        padding: 3px 10px;
+        box-shadow: inset 0 0 3px #454949;
+        width: auto;
+        margin: 0 2px;
+      }
     }
-    .gd-open-tags {
-      float: right;
-      width: auto;
-      align-content: center;
-      margin: 0 6px;
-      padding: 5px 0 0 0;
-      text-align: right;
-    }
-    .gd-open-category, .gd-open-status {
-      display: inline-block;
-      border-radius: 5px;
-      font-size: 1rem;
-      padding: 5px 10px;
-      box-shadow: inset 0 0 3px black;
-      width: auto;
-      margin: 0 2px;
-      color: black;
-    }
-    hr {
-      width: calc(100% - 10px);
-      margin: 10px auto;
-    }
-    .gd-open-question {
-      font-size: 2rem;
-      width: 100%;
-      text-align: center;
-      margin-top: 5px;
-    }
-    .gd-image {
-      display: block;
-      max-height: 300px;
-      border: 1px solid black;
-      border-radius: 5px;
-      box-shadow: 0 0 3px black;
-      margin: 0 auto;
+    .gd-host-tools {
+      display: flex;
+      width: 300px;
+      div {
+        width: 50%;
+      }
+      button {
+        display: block;
+        border-radius: 5px;
+        margin: 5px;
+        font-size: 1rem;
+        padding: 5px 10px;
+        width: calc(100% - 5px);
+        min-height: 36px;
+        box-shadow: 0 0 5px black;
+        align-content: center;
+      }
     }
   }
-  .gd-closed {
-    border-left: 2px solid aliceblue;
-    border-right: 2px solid aliceblue;
-    min-height: 97vh;
-    margin-top: 10px;
-    padding: 0 10px;
-    max-width: 330px;
-    h3 {
-      width: 100%;
-      text-align: center;
-    }
-    .gd-closed-container {
-      display: flex;
-      flex-flow: row wrap;
-      gap: 10px;
-      color: black;
-      justify-content: center;
-      .q-card:last-of-type {
-        margin: 0;
+  .gd-container {
+    display: flex;
+    .gd-unused, .gd-open-host, .gd-open-player, .gd-closed, .gd-released {
+      border-left: 2px solid aliceblue;
+      padding: 0 10px;
+      margin: 10px 0 0 0;
+      height: 78vh;
+      h3 {
+        width: 100%;
+        text-align: center;
+        text-shadow: 3px 3px black;
       }
+      .gd-card-container {
+        display: flex;
+        flex-flow: row wrap;
+        gap: 10px;
+        justify-content: center;
+        .q-card:last-of-type {
+          margin: 0;
+        }
+      }
+    }
+    .gd-unused {
+      min-width: 330px;
+      flex: 1;
+    }
+    .gd-open-host {
+      width: 330px;
+    }
+    .gd-open-player {
+      flex: 1;
+      min-width: 330px;
+      h2 {
+        width: 100%;
+        text-align: center;
+      }
+      .gd-open-tags {
+        float: right;
+        width: auto;
+        align-content: center;
+        margin: 0 6px;
+        padding: 5px 0 0 0;
+        text-align: right;
+      }
+      .gd-open-category, .gd-open-status {
+        display: inline-block;
+        border-radius: 5px;
+        font-size: 1rem;
+        padding: 5px 10px;
+        box-shadow: inset 0 0 3px black;
+        width: auto;
+        margin: 0 2px;
+        color: black;
+      }
+      hr {
+        width: calc(100% - 10px);
+        margin: 10px auto;
+      }
+      .gd-open-question {
+        font-size: 2rem;
+        width: 100%;
+        text-align: center;
+        margin-top: 5px;
+      }
+      .gd-image {
+        display: block;
+        max-height: 300px;
+        border: 1px solid black;
+        border-radius: 5px;
+        box-shadow: 0 0 3px black;
+        margin: 0 auto;
+      }
+    }
+    .gd-closed {
+      width: 330px;
+    }
+    .gd-released {
+      border-right: 2px solid aliceblue;
+      margin-top: 10px;
+      padding: 0 10px;
+      width: 330px;
     }
   }
 }


### PR DESCRIPTION
## Description
Adapted GameDisplay for use in host environment, with additional columns for unused and closed questions ('closed' renamed 'released' for many-to-many), and host tool buttons (non-functional)
Created merged API calls for retrieving questions with gameQuestion info (getGameQuestions) and full game data in a single object (getFullGameData)

## Related Issue
#8 

## Motivation and Context
As a host user, I want to manage my games, so I need an interface through which to do that. I can at a glance see the status of all the questions in my game.

## How Can This Be Tested?
Navigate to /host/game/[id], should see display below with game specific questions listed

## Screenshots (if appropriate):
![image](https://github.com/alexberka/a-trivial-glance/assets/148516337/4efcf9be-87cd-400a-bbd8-1dc6889d31e2)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
