### PR TITLE
HOST - Change Game Status

### DIFF
--- a/components/GameDisplay.js
+++ b/components/GameDisplay.js
@@ -102,8 +102,7 @@ export default function GameDisplay({ game, host, onUpdate }) {
             <h3>Unused</h3>
             <div className="gd-fade-captive">
               <div className="gd-card-container">
-                {game.questions.map((q) => (<QuestionCard key={q.firebaseKey} questionObj={q} host />))}
-                {game.questions.map((q) => (<QuestionCard key={q.firebaseKey} questionObj={q} host />))}
+                {display.unusedQ.map((q) => (<QuestionCard key={q.firebaseKey} questionObj={q} host />))}
               </div>
               <div className="gd-scroll-fade" />
             </div>

--- a/components/GameDisplay.js
+++ b/components/GameDisplay.js
@@ -5,9 +5,10 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 import QuestionCard from './QuestionCard';
 import { deleteGame } from '../api/mergedData';
+import { updateGame } from '../api/gameData';
 
 // 'questions' contains questions for game with attached category objects
-export default function GameDisplay({ game, host }) {
+export default function GameDisplay({ game, host, onUpdate }) {
   const router = useRouter();
 
   const display = {
@@ -29,45 +30,93 @@ export default function GameDisplay({ game, host }) {
     }
   };
 
+  const handleStatus = (e) => {
+    const payload = { firebaseKey: game.firebaseKey };
+    if (e.target.id === 'toggle') {
+      payload.dateLive = new Date().toISOString();
+      if (game.status === 'unused' || game.status === 'closed') {
+        payload.status = 'live';
+      } else {
+        payload.status = 'closed';
+      }
+    } else if (e.target.id === 'reset') {
+      payload.dateLive = 'never';
+      payload.status = 'unused';
+    }
+    updateGame(payload).then(onUpdate);
+  };
+
   return (
     <div className="game-display">
       <div className="gd-header">
         <div className="gd-title-box">
-          <span>
-            <h1>{game.name}</h1>
-            {game.status === 'live' && (<span className="status-live gd-game-live">LIVE</span>)}
-          </span>
+          <h1>{game.name}</h1>
           <h2>{game.location}</h2>
         </div>
-        {host && (
-          <div className="gd-host-tools">
+        <div className="gd-header-buttons">
+          <div>
+            <span className={`status-${game.status} gd-game-status`}>
+              {game.status.toUpperCase()}
+              {game.status === 'closed' && (
+                <p>
+                  {new Date(game.dateLive).toDateString()
+                    .split(' ')
+                    .splice(1)
+                    .join(' ')}
+                </p>
+              )}
+            </span>
+            {host && (
+              <>
+                <button
+                  className={`gd-status-toggle${game.status === 'live' ? '-closed' : '-live'}`}
+                  type="button"
+                  id="toggle"
+                  onClick={handleStatus}
+                >
+                  {game.status === 'live' ? 'Close Game' : 'Go Live'}
+                </button>
+                {display.unusedQ.length < game.questions.length ? (
+                  <button type="button">Reset Questions</button>
+                )
+                  : game.status !== 'unused' && (
+                  <button className="gd-status-reset" type="button" id="reset" onClick={handleStatus}>Reset Game</button>
+                  )}
+              </>
+            )}
+          </div>
+          {host && (
             <div>
               <button type="button">Add Question</button>
-              <button type="button">{game.status === 'live' ? 'Close Game' : 'Go Live'}</button>
-            </div>
-            <div>
               <Link passHref href={`/host/game/edit/${game.firebaseKey}`}>
                 <button type="button">Edit</button>
               </Link>
               <button type="button" onClick={handleDelete}>Delete</button>
             </div>
-          </div>
-        )}
+          )}
+        </div>
       </div>
       <div className="gd-container">
         {host && (
           <div className="gd-unused">
             <h3>Unused</h3>
-            <div className="gd-card-container">
-              {display.unusedQ.map((q) => (<QuestionCard key={q.firebaseKey} questionObj={q} host />))}
+            <div className="gd-fade-captive">
+              <div className="gd-card-container">
+                {game.questions.map((q) => (<QuestionCard key={q.firebaseKey} questionObj={q} host />))}
+                {game.questions.map((q) => (<QuestionCard key={q.firebaseKey} questionObj={q} host />))}
+              </div>
+              <div className="gd-scroll-fade" />
             </div>
           </div>
         )}
         {host ? (
           <div className="gd-open-host">
             <h3>Open</h3>
-            <div className="gd-card-container">
-              {display.openQ && (<QuestionCard questionObj={display.openQ} host />)}
+            <div className="gd-fade-captive">
+              <div className="gd-card-container">
+                {display.openQ && (<QuestionCard questionObj={display.openQ} host />)}
+              </div>
+              <div className="gd-scroll-fade" />
             </div>
           </div>
         ) : (
@@ -99,16 +148,22 @@ export default function GameDisplay({ game, host }) {
         {host && (
           <div className="gd-closed">
             <h3>Closed</h3>
-            <div className="gd-card-container">
-              {display.closedQ.map((q) => (<QuestionCard key={q.firebaseKey} questionObj={q} host />))}
+            <div className="gd-fade-captive">
+              <div className="gd-card-container">
+                {display.closedQ.map((q) => (<QuestionCard key={q.firebaseKey} questionObj={q} host />))}
+              </div>
+              <div className="gd-scroll-fade" />
             </div>
           </div>
         )}
         <div className="gd-released">
           {/* Display closed question(s), if any */}
           <h3>{host ? 'Released' : 'Past Questions'}</h3>
-          <div className="gd-card-container">
-            {display.releasedQ.map((q) => (<QuestionCard key={q.firebaseKey} questionObj={q} host />))}
+          <div className="gd-fade-captive">
+            <div className="gd-card-container">
+              {display.releasedQ.map((q) => (<QuestionCard key={q.firebaseKey} questionObj={q} host />))}
+            </div>
+            <div className="gd-scroll-fade" />
           </div>
         </div>
       </div>
@@ -122,6 +177,7 @@ GameDisplay.propTypes = {
     location: PropTypes.string,
     status: PropTypes.string,
     firebaseKey: PropTypes.string,
+    dateLive: PropTypes.string,
     questions: PropTypes.arrayOf(PropTypes.shape({
       question: PropTypes.string,
       answer: PropTypes.string,
@@ -138,8 +194,10 @@ GameDisplay.propTypes = {
     })),
   }).isRequired,
   host: PropTypes.bool,
+  onUpdate: PropTypes.func,
 };
 
 GameDisplay.defaultProps = {
   host: false,
+  onUpdate: null,
 };

--- a/pages/host/game/[id].js
+++ b/pages/host/game/[id].js
@@ -8,13 +8,17 @@ export default function ManageGame() {
   const [gameData, setGameData] = useState();
   const router = useRouter();
 
-  useEffect(() => {
+  const grabGame = () => {
     getFullGameData(router.query.id).then(setGameData);
+  };
+
+  useEffect(() => {
+    grabGame();
   }, []);
 
   return (
     <div>
-      {gameData && (<GameDisplay game={gameData} host />)}
+      {gameData && (<GameDisplay game={gameData} host onUpdate={grabGame} />)}
     </div>
   );
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -5,8 +5,15 @@ html,
 body {
   padding: 0;
   margin: 0;
+  height: 100%;
   font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
     Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+}
+
+:root {
+  --main-color-1: #454949;
+  --btn-shadow-up: inset 0 0 5px black, inset 2px 2px 5px 0 #e5e9e975, 2px 2px 3px black;
+  --btn-shadow-down: inset 0px 0px 7px black, inset 2px 2px 7px 0 #e5e9e975, 1px 1px 2px black;
 }
 
 a {
@@ -19,7 +26,7 @@ a {
 }
 
 body {
-  background-color: #454949;
+  background-color: var(--main-color-1);
 }
 
 .nav-collapsed {
@@ -53,7 +60,7 @@ body {
   padding: 0 0 5px 0;
   border-bottom-right-radius: 5px;
   z-index: 4;
-  box-shadow: 0 0 3px black;
+  box-shadow: var(--btn-shadow-up);
   .nav-logo {
     height: 36px;
     position: relative;
@@ -181,7 +188,7 @@ body {
   margin-bottom: auto;
   overflow: hidden;
   border-radius: 5px;
-  box-shadow: inset 0 0 3px black;
+  box-shadow: var(--btn-shadow-up);
   cursor: pointer;
   .g-card-name {
     margin: 0;
@@ -207,7 +214,7 @@ body {
     border-radius: 5px;
     font-size: 0.7rem;
     padding: 3px 6px;
-    box-shadow: inset 0 0 3px #454949;
+    box-shadow: inset 0 0 3px var(--main-color-1);
     width: auto;
     margin: 0 2px;
   }
@@ -234,7 +241,7 @@ body {
   overflow: hidden;
   transition: max-height 1s;
   border-radius: 5px;
-  box-shadow: inset 0 0 3px black;
+  box-shadow: var(--btn-shadow-up);
   cursor: pointer;
   .q-card-text {
     margin: 0;
@@ -253,7 +260,7 @@ body {
     border-radius: 5px;
     font-size: 0.7rem;
     padding: 3px 6px;
-    box-shadow: inset 0 0 3px #454949;
+    box-shadow: inset 0 0 3px var(--main-color-1);
     width: auto;
     margin: 0 2px;
   }
@@ -270,7 +277,7 @@ body {
 }
 
 .status-unused {
-  background: #b0cccc;
+  background: #b5b9b9;
 }
 .status-open, .status-live {
   background: #82e782;
@@ -322,7 +329,7 @@ body {
       padding: 5px 10px;
       width: 100%;
       min-height: 36px;
-      box-shadow: 0 0 5px black;
+      box-shadow: var(--btn-shadow-up);
       align-content: center;
     }
     .qd-category {
@@ -333,22 +340,57 @@ body {
         text-align: center;
         width: 100%;
         align-content: center;
+        border-radius: 4px 0 0 4px;
+        box-shadow: var(--btn-shadow-up);
+        /* text-shadow: 0 0 3px aliceblue; */
       }
       .qd-category-toggle {
         background: none;
         border: none;
-        border-left: 2px solid black;
+        border-radius: 0 4px 4px 0;
         margin: 0 0 0 auto;
         padding: 0 10px;
         font-size: 1rem;
+        box-shadow: var(--btn-shadow-up);
       }
       .qd-category-toggle:hover {
-        background:#454949;
+        background: black;
         color: aliceblue;
         border-radius: 0 4px 4px 0;
       }
       .qd-category-toggle:active {
-        box-shadow: inset 0 0 2px black;
+        box-shadow: var(--btn-shadow-down);
+      }
+    }
+    .category-menu {
+      position: absolute;
+      top: 38px;
+      right: 0px;
+      background: rgb(37, 37, 37);;
+      color: aliceblue;
+      width: 80%;
+      box-shadow: var(--btn-shadow-up);
+      border-radius: 5px;
+      margin: 0 0 0 20%;
+      cursor: default;
+      z-index: 3;
+      text-align: center;
+      .category-item {
+        display: block;
+        padding: 1px 0;
+        background: none;
+        border: none;
+        color: aliceblue;
+        width: 100%;
+      }
+      button:hover {
+        background: #45494970;
+      }
+      button:first-of-type:hover {
+        border-radius: 5px 5px 0px 0px;
+      }
+      button:last-of-type:hover {
+        border-radius: 0px 0px 5px 5px;
       }
     }
     .qd-return {
@@ -382,41 +424,22 @@ body {
         font-size: 1.2rem;
         padding: 5px 10px;
         width: 100%;
+        box-shadow: var(--btn-shadow-up);
+      }
+      button:active {
+        box-shadow: var(--btn-shadow-down);
       }
     }
   }
 }
 
-.category-menu {
-  position: absolute;
-  top: 38px;
-  right: 0px;
-  background: #353939;
-  color: aliceblue;
-  width: 80%;
-  box-shadow: 0 0 3px black;
-  border-radius: 5px;
-  margin: 0 0 0 20%;
-  cursor: default;
-  z-index: 3;
-  text-align: center;
-  .category-item {
-    display: block;
-    padding: 1px 0;
-    border-radius: 5px;
-    background: none;
-    border: none;
-    color: aliceblue;
-    width: 100%;
-  }
-  button:hover {
-    background: black;
-  }
-}
 
 .game-display {
   color: aliceblue;
   width: 100%;
+  height: 96vh;
+  display: flex;
+  flex-flow: column;
   .gd-header {
     position: relative;
     width: 100%;
@@ -424,7 +447,6 @@ body {
     margin-top: 10px;
     display: flex;
     gap: 40px;
-    align-items: last baseline;
     .gd-title-box {
       flex: 1;
       max-width: calc(100% - 300px - 40px);
@@ -440,64 +462,119 @@ body {
         font-size: 2rem;
         font-style: italic;
       }
-      span {
-        position: relative;
+    }
+    .gd-header-buttons {
+      display: flex;
+      gap: 5px;
+      div {
+        width: 150px;
       }
-      .gd-game-live {
-        position: absolute;
-        display: inline-block;
-        top: -2.1rem;
-        right: -90px;
-        font-size: 1.3rem;
+      .gd-game-status {
+        display: block;
+        position: relative;
+        font-size: 1.2rem;
         color: black;
-        display: inline-block;
         border-radius: 5px;
         padding: 3px 10px;
-        box-shadow: inset 0 0 5px black;
+        box-shadow: var(--btn-shadow-up);
         border: 1px solid black;
-        width: auto;
-        margin: 0 2px;
-      }
-    }
-    .gd-host-tools {
-      display: flex;
-      width: 300px;
-      div {
-        width: 50%;
+        width: 100%;
+        margin-bottom: 5px;
+        height: 36px;
+        pointer-events: none;
+        p {
+          position: absolute;
+          margin: 0;
+          bottom: 0px;
+          right: 0px;
+          font-size: 0.6rem;
+          background-color: #35393990;
+          padding: 1px 3px;
+          border-radius: 5px 1px 5px 1px;
+          color: rgba(240, 248, 255, 0.803);
+          text-shadow: 1px 1px 1px black;
+        }
       }
       button {
         display: block;
         border-radius: 5px;
-        margin: 5px;
+        border: none;
+        margin-bottom: 5px;
         font-size: 1rem;
         padding: 5px 10px;
-        width: calc(100% - 5px);
+        width: 100%;
         min-height: 36px;
-        box-shadow: 0 0 5px black;
+        box-shadow: var(--btn-shadow-up);
         align-content: center;
+        background-color: #353939;
+        color: aliceblue;
+      }
+      button:active {
+        box-shadow: var(--btn-shadow-down);
+        border: 1px solid #353939;
+      }
+      button:hover {
+        background: black;
+      }
+      .gd-status-toggle-live:hover {
+        background-color: #82e782;
+        color: black;
+      }
+      .gd-status-toggle-closed:hover {
+        background-color: #e67c7c;
+        color: black;
+      }
+      .gd-status-reset:hover {
+        background-color: #b5b9b9;
+        color: black;
       }
     }
   }
   .gd-container {
     display: flex;
+    flex: 1;
+    height: 100%;
     .gd-unused, .gd-open-host, .gd-open-player, .gd-closed, .gd-released {
+      position: relative;
       border-left: 2px solid aliceblue;
-      padding: 0 10px;
+      padding: 0 5px;
       margin: 10px 0 0 0;
-      height: 78vh;
+      height: 76vh;
       h3 {
         width: 100%;
         text-align: center;
         text-shadow: 3px 3px black;
+        margin: 0;
       }
       .gd-card-container {
         display: flex;
         flex-flow: row wrap;
         gap: 10px;
         justify-content: center;
-        .q-card:last-of-type {
-          margin: 0;
+        width: 100%;
+        max-height: calc(100% - 3rem);
+        overflow-y: auto;
+        scrollbar-width: none;
+        scrollbar-color: #00000050 var(--main-color-1);
+        .q-card:first-of-type {
+          margin-top: 10px;
         }
+        .q-card:last-of-type {
+          margin-right: 0;
+          margin-bottom: 10px;
+        }
+      }
+      .gd-scroll-fade {
+        height: calc(100% - 48px);
+        width: 100%;
+        position: absolute;
+        top: 32px;
+        left: 0;
+        box-shadow: inset 0 30px 5px -20px var(--main-color-1), inset 0 -30px 8px -20px var(--main-color-1);
+        pointer-events: none;
+      }
+      .gd-fade-captive {
+        height: 99%;
       }
     }
     .gd-unused {
@@ -557,7 +634,7 @@ body {
     .gd-released {
       border-right: 2px solid aliceblue;
       margin-top: 10px;
-      padding: 0 10px;
+      padding: 0 5px;
       width: 330px;
     }
   }


### PR DESCRIPTION
## Description
Added functionality for opening, closing, and resetting games
Games can be reset (to unused, clearing timestamp) given questions have been reset (not yet implemented)

Styling changes buttons, shadows, in-column scrolling on game display

## Related Issue
#18 

## Motivation and Context
As a host user, I want the ability to open my games to make them visible to players, and close them at game end. I also may want to reset a game, if I had been testing it or want to recategorize it not to sort with closed games.

## How Can This Be Tested?
On a game details page '/host/game/[id]', if the game is 'unused' or 'closed', click 'Go Live' to open it. Indicator will switch to 'LIVE'. If the game is Live, click 'Close Game' to close it; indicator will switch to 'CLOSED' with timestamp of date opened. If all questions in a game are unused, 'Reset Questions' will be 'Reset Game', which will revert the game to 'UNUSED' and clear the timestamp. 'Reset Questions' functionality to be added with 'open/close questions feature'.

## Screenshots (if appropriate):
![image](https://github.com/alexberka/a-trivial-glance/assets/148516337/18e8bf97-0046-484c-bdd5-01194ac0c0ba)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
