### PR TITLE
HOST - Manage Question Status

### DIFF
--- a/api/mergedData.js
+++ b/api/mergedData.js
@@ -1,6 +1,11 @@
 import { getCategories, getCategoryById } from './categoriesData';
 import { deleteGameOnly, getGameById, getGamesByHost } from './gameData';
-import { deleteGameQuestion, getGameQuestionsByGame } from './gameQuestionsData';
+import {
+  getGameQuestionById,
+  getGameQuestionsByGame,
+  updateGameQuestion,
+  deleteGameQuestion,
+} from './gameQuestionsData';
 import { getQuestionByIdNoCat, getQuestionsByHostNoCats, getQuestionsNoCats } from './questionsData';
 
 const getQuestions = async () => {
@@ -37,6 +42,20 @@ const getGameQuestions = async (gameId) => {
   }));
 };
 
+const getFullGameQuestion = async (gameQuestionId) => {
+  const gameQuestion = await getGameQuestionById(gameQuestionId);
+  const question = await getQuestionById(gameQuestion.questionId);
+  const game = await getGameById(gameQuestion.gameId);
+  return {
+    ...question,
+    status: gameQuestion.status,
+    timeOpened: gameQuestion.timeOpened,
+    queue: gameQuestion.queue,
+    gameQuestionId: gameQuestion.firebaseKey,
+    game,
+  };
+};
+
 // Retrieves a game with its gameQuestions(+associated question & category data)
 const getFullGameData = async (gameId) => {
   const gameInfo = await getGameById(gameId);
@@ -58,12 +77,19 @@ const deleteGame = async (firebaseKey) => {
   await deleteGameOnly(firebaseKey);
 };
 
+const resetAllQuestions = async (questions) => {
+  const resetGQs = questions.map((q) => updateGameQuestion({ firebaseKey: q.gameQuestionId, status: 'unused', timeOpened: 'never' }));
+  await Promise.all(resetGQs);
+};
+
 export {
   getQuestions,
   getQuestionsByHost,
   getQuestionById,
   getGameQuestions,
+  getFullGameQuestion,
   getFullGameData,
   getGameCardsData,
   deleteGame,
+  resetAllQuestions,
 };

--- a/components/QuestionCard.js
+++ b/components/QuestionCard.js
@@ -8,7 +8,10 @@ export default function QuestionCard({ questionObj, host }) {
   return (
     // If host is set to true, clicking the card will direct to the question's details page with host tools
     // Otherwise, clicking will direct to player view of question (/question/[id] redirects if question isn't closed)
-    <Link passHref href={`${host ? '/host' : ''}/question/${questionObj.firebaseKey}`}>
+    <Link
+      passHref
+      href={`${host ? '/host' : ''}/question/${questionObj.firebaseKey}/${questionObj.gameQuestionId ? questionObj.gameQuestionId : ''}`}
+    >
       <div className="q-card">
         <div className="q-card-tags">
           <p className="q-category" style={{ background: `${questionObj.category.color}` }}>
@@ -20,7 +23,7 @@ export default function QuestionCard({ questionObj, host }) {
             </p>
           )}
           {/* Include the date of last usage if in host view (creates date from ISO String in database) */}
-          {host && (
+          {host && !questionObj.gameQuestionId && (
             <p className="q-timestamp">
               {questionObj.lastUsed !== 'never'
                 ? `Last Used: ${new Date(questionObj.lastUsed)

--- a/pages/delete-me.js
+++ b/pages/delete-me.js
@@ -1,5 +1,0 @@
-import React from 'react';
-
-export default function DeleteMe() {
-  return <div>DeleteMe</div>;
-}

--- a/pages/host/question/[id].js
+++ b/pages/host/question/[id].js
@@ -31,7 +31,7 @@ export default function ManageQuestion() {
     setEditing((prev) => !prev);
   };
 
-  // Makes another call to firebase to retireve the question data
+  // Makes another call to firebase to retrieve the question data
   // (also includes category object from getQuestionById merge call)
   // 'toggle' can be set to false to bypass toggle of 'editing' state
   const onUpdate = (toggle = true) => {

--- a/pages/host/question/[id]/[gameQuestionId].js
+++ b/pages/host/question/[id]/[gameQuestionId].js
@@ -1,0 +1,24 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import QuestionDetails from '../../../../components/QuestionDetails';
+import { getFullGameQuestion } from '../../../../api/mergedData';
+
+export default function ManageGameQuestion() {
+  const [question, setQuestion] = useState({});
+  const router = useRouter();
+
+  const onUpdate = () => {
+    getFullGameQuestion(router.query.gameQuestionId).then(setQuestion);
+  };
+
+  useEffect(() => {
+    onUpdate();
+  }, []);
+
+  return (
+    <div>
+      {question.firebaseKey && (<QuestionDetails questionObj={question} host onUpdate={onUpdate} />)}
+    </div>
+  );
+}


### PR DESCRIPTION
## Description
Built /host/question/[id]/[gameQuestionId] page
Clicking on a question in the game details panel directs host to game-specific question page

For live games, a host user may open/close a question from the question details page (if the question has gameQuestion info attached, that is, user is viewing information for a specific instance of the question within a game, and not the full question itself).
For all games, a host user may release/hide a question's answer or reset the question from the question details page.
Also added functionality to 'Reset Questions' button on host game details page to reset all questions back to unused.
Closing a game closes any open questions.

Created merged calls to get a full game question (gameQuestion w/ question and game data attached) and reset all questions in a game.

Player game details page displays the most recent question, regardless of status (unless 'unused'). If that question is released, the answer will appear beneath it (player-side game details page does not have a 'released' indicator and reads both 'closed' and 'released' questions as 'closed').

## Related Issue
#45 

## Motivation and Context
As a host, I want to be able to manage the status of my questions to advance through the game.

Now, players can see a succession of questions as the host opens, closes, and releases questions in the game.

## How Can This Be Tested?
As a host on the game details page, click on a question card.
Verify question details page displays information about that instance of the question in the game.
Depending on the question's status, buttons will appear to open/close the question (if the game is live), release/hide the answer, and reset the question. Verify these changes work as expected.
Only one question may be open per game at a time, so opening one while another is still open will notify that the action will close the current question first.
From the game details page, test the 'Reset Questions' button, which will move all questions back into the 'Unused' column and reassign their status as such, erasing timestamps.
Closing a game will also move the currently open question to closed.

As a player user, verify that the game details page displays the most recent question and its status, and if that question is released, also its answer.

## Screenshots (if appropriate):
In the game 'Blade II', question is closed:
![image](https://github.com/alexberka/a-trivial-glance/assets/148516337/6be8e21a-d1d1-47f5-8623-67683ba0940e)

After releasing the answer, in player game details:
![image](https://github.com/alexberka/a-trivial-glance/assets/148516337/c3b55347-0759-4a48-9d65-ad83bf49ded8)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
