### PR TITLE
Hosts add/remove questions to/from games

### DIFF
--- a/components/QuestionDetails.js
+++ b/components/QuestionDetails.js
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import CategoryDropdown from './forms/CategoryDropdown';
 import { getGameQuestionsByGame, updateGameQuestion } from '../api/gameQuestionsData';
 import { updateQuestion } from '../api/questionsData';
+import GameDropdown from './forms/GameDropdown';
 
 // 'questionObj' includes a single question object with associated category object embedded
 // 'host' is a boolean indicating whether user is in host mode (defaults to false)
@@ -106,34 +107,12 @@ export default function QuestionDetails({
       <div className="qd-buttons">
         {/* If in host view, use CategoryDropdown component (see CategoryDropdown.js for prop notes) */}
         {/* Otherwise display category as non-interactive element */}
-        {host ? (
+        {host && !questionObj.gameQuestionId ? (
           <CategoryDropdown selectedCategoryId={questionObj.category.firebaseKey} questionId={questionObj.firebaseKey} />
         ) : (
-          <p className="qd-status" style={{ background: `${questionObj.category.color}` }}>
+          <p className="qd-btn qd-status" style={{ background: `${questionObj.category.color}` }}>
             {questionObj.category.name.toUpperCase()}
           </p>
-        )}
-        {questionObj.gameQuestionId && (
-          <>
-            <p className={`qd-status status-${questionObj.status}`}>
-              {questionObj.status.toUpperCase()}
-            </p>
-            <p>in <i>{questionObj.game.name}</i></p>
-            <Link passHref href={`/host/game/${questionObj.game.firebaseKey}`}>
-              <button type="button" className={`qd-status status-${questionObj.game.status}`}>
-                Back To Game
-              </button>
-            </Link>
-          </>
-        )}
-        {/* If in player view, include button to return to current game */}
-        {!host
-        && (
-          <Link passHref href="/game">
-            <button type="button" className="qd-return">
-              RETURN TO GAME
-            </button>
-          </Link>
         )}
         {/* If in host view, display the timestamp of the last day the question was used */}
         {(host && !questionObj.gameQuestionId)
@@ -147,22 +126,58 @@ export default function QuestionDetails({
             : 'Last Used: Never'}
         </p>
         )}
+        {questionObj.gameQuestionId ? (
+          <>
+            <p className={`qd-btn qd-status status-${questionObj.status}`}>
+              {questionObj.status.toUpperCase()}
+            </p>
+            <Link passHref href={`/host/game/${questionObj.game.firebaseKey}`}>
+              <button type="button" className={`qd-btn qd-game-status status-${questionObj.game.status}`}>
+                <i>{questionObj.game.name}</i>
+              </button>
+            </Link>
+            <Link passHref href={`/host/question/${questionObj.firebaseKey}`}>
+              <button type="button" className="qd-btn">
+                Edit Question...
+              </button>
+            </Link>
+          </>
+        ) : (
+          <>
+            <GameDropdown />
+          </>
+        )}
+        {/* If in player view, include button to return to current game */}
+        {!host
+        && (
+          <Link passHref href="/game">
+            <button type="button" className="qd-return qd-btn">
+              RETURN TO GAME
+            </button>
+          </Link>
+        )}
         {/* If in host view, display status, edit, and delete host tools */}
         {host && (
           <div className="qd-host-tools">
             {questionObj.gameQuestionId ? (
               <>
                 {(questionObj.status === 'closed' || questionObj.status === 'released') && (
-                  <button type="button" onClick={handleStatus} value="reset">Reset Question</button>
+                  <button type="button" onClick={handleStatus} value="reset" className="qd-btn">
+                    Reset Question
+                  </button>
                 )}
                 {questionObj.status === 'closed' && (
-                  <button type="button" onClick={handleStatus} value="release">Release Answer</button>
+                  <button type="button" onClick={handleStatus} value="release" className="qd-btn">
+                    Release Answer
+                  </button>
                 )}
                 {questionObj.status === 'released' && (
-                  <button type="button" onClick={handleStatus} value="unrelease">Hide Answer</button>
+                  <button type="button" onClick={handleStatus} value="unrelease" className="qd-btn">
+                    Hide Answer
+                  </button>
                 )}
                 {questionObj.game.status === 'live' && (
-                  <button type="button" onClick={handleStatus}>
+                  <button type="button" onClick={handleStatus} className="qd-btn">
                     {questionObj.status === 'unused' && 'Open Question'}
                     {questionObj.status === 'open' && 'Close Question'}
                     {(questionObj.status === 'closed' || questionObj.status === 'released') && 'Reopen Question'}
@@ -171,8 +186,8 @@ export default function QuestionDetails({
               </>
             ) : (
               <>
-                <button type="button" onClick={onUpdate}>Edit</button>
-                <button type="button" onClick={handleDelete}>Delete</button>
+                <button type="button" onClick={onUpdate} className="qd-btn">Edit</button>
+                <button type="button" onClick={handleDelete} className="qd-btn">Delete</button>
               </>
             )}
           </div>

--- a/components/forms/CategoryDropdown.js
+++ b/components/forms/CategoryDropdown.js
@@ -46,7 +46,7 @@ export default function CategoryDropdown({ questionId, selectedCategoryId, form 
   return (
     // If menu is open and the mouse leaves, close the menu
     <div className="category-dropdown" onMouseLeave={() => handleToggle('only-if-open')}>
-      <div className="qd-category" style={{ background: `${form || !categories ? 'white' : categories[menuState.selected].color}` }}>
+      <div className="qd-category qd-btn" style={{ background: `${form || !categories ? 'white' : categories[menuState.selected].color}` }}>
         {/* Display loading message until categories have been retrieved */}
         {categories ? (
           <div className="qd-category-name">

--- a/components/forms/GameDropdown.js
+++ b/components/forms/GameDropdown.js
@@ -1,0 +1,121 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import Link from 'next/link';
+import {
+  createGameQuestion,
+  deleteGameQuestion,
+  getGameQuestionsByQuestion,
+  updateGameQuestion,
+} from '../../api/gameQuestionsData';
+import { getGamesByHost } from '../../api/gameData';
+import { useAuth } from '../../utils/context/authContext';
+
+export default function GameDropdown() {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [games, setGames] = useState([]);
+  const [gameQuestions, setGameQuestions] = useState([]);
+  const [search, setSearch] = useState('');
+
+  const assigned = gameQuestions?.map((gq) => {
+    const gameInfo = games?.find((g) => g.firebaseKey === gq.gameId);
+    return { ...gq, name: gameInfo?.name };
+  });
+  const unassigned = games
+    .filter((g) => !assigned.some((ag) => ag.gameId === g.firebaseKey))
+    .filter((g) => g.name.toLowerCase().includes(search.toLowerCase()))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  const router = useRouter();
+  const { user } = useAuth();
+
+  // Toggles menu open and closed
+  // If called as handleToggle('only-if-open'), menu is only closed if open, but not opened if currently closed
+  const handleToggle = (restrict) => {
+    setMenuOpen((prev) => (restrict === 'only-if-open' ? false : !prev));
+  };
+
+  const handleSearch = (e) => {
+    if (e.target.name === 'dropdown-search') {
+      setSearch(e.target.value);
+    }
+  };
+
+  const updateGameList = () => {
+    getGameQuestionsByQuestion(router.query.id).then(setGameQuestions);
+  };
+
+  useEffect(() => {
+    getGamesByHost(user.uid).then(setGames);
+    updateGameList();
+  }, []);
+
+  const handleClick = (e) => {
+    const { value } = e.target;
+    const payload = {
+      questionId: router.query.id,
+      gameId: value,
+      status: 'unused',
+      timeOpened: 'never',
+      queue: 0,
+    };
+    createGameQuestion(payload).then(({ name }) => {
+      updateGameQuestion({ firebaseKey: name })
+        .then(updateGameList)
+        .then(handleToggle)
+        .then(() => setSearch(''));
+    });
+  };
+
+  const handleRemove = (e) => {
+    if (window.confirm(`Remove this question from ${e.target.id}?`)) {
+      deleteGameQuestion(e.target.value)
+        .then(updateGameList);
+    }
+  };
+
+  return (
+    <div className="game-dropdown">
+      {assigned.length > 0 && (
+        <>
+          <hr />
+          <p>Games</p>
+          <div className="assigned-list">
+            {assigned.map((gq) => (
+              <div key={gq.firebaseKey} className="assigned-game">
+                <Link passHref href={`/host/question/${router.query.id}/${gq.firebaseKey}`}>
+                  <button type="button">
+                    <div className="qd-gq-status"><span className={`status-tag status-${gq.status}`}>{gq.status.toUpperCase()}</span> in</div>
+                    <div className="qd-gq-game">{gq.name}</div>
+                  </button>
+                </Link>
+                <button type="button" onClick={handleRemove} id={gq.name} value={gq.firebaseKey} className="gq-remove">X</button>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+      <div className="dropdown-element" onMouseLeave={() => handleToggle('only-if-open')}>
+        <div className="qd-assign-game qd-btn">
+          <div className="qd-game-name">
+            Add to...
+          </div>
+          {/* Toggle dropdown open/close on click of arrow button */}
+          <button type="button" className="qd-game-toggle" onClick={handleToggle}>
+            {menuOpen ? '▲' : '▼'}
+          </button>
+        </div>
+        {menuOpen && (
+        <div className="assign-game-menu">
+          <input type="text" onChange={handleSearch} name="dropdown-search" value={search} placeholder="Search Games..." className="sticky-search" />
+          <div className="game-menu-container">
+            {unassigned.map((game) => (
+              <button type="button" className="game-item" key={game.firebaseKey} name="gameId" value={game.firebaseKey} onClick={handleClick}>{game.name}</button>
+            ))}
+          </div>
+        </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -379,7 +379,8 @@ body {
     height: 90vh;
     text-align: center;
     width: 200px;
-    .qd-category, .qd-status, .qd-return {
+    .qd-btn {
+      border: none;
       border-radius: 5px;
       margin: 5px 0;
       font-size: 1rem;
@@ -389,67 +390,228 @@ body {
       box-shadow: var(--btn-shadow-up);
       align-content: center;
     }
-    .qd-category {
-      display: flex;
-      padding: 0;
-      .qd-category-name {
-        padding: 5px;
+    .category-dropdown {
+      .qd-category {
+        display: flex;
+        padding: 0;
+        .qd-category-name {
+          padding: 5px;
+          text-align: center;
+          width: 100%;
+          align-content: center;
+          border-radius: 4px 0 0 4px;
+          box-shadow: var(--btn-shadow-up);
+          /* text-shadow: 0 0 3px aliceblue; */
+        }
+        .qd-category-toggle {
+          background: none;
+          border: none;
+          border-radius: 0 4px 4px 0;
+          margin: 0 0 0 auto;
+          padding: 0 10px;
+          font-size: 1rem;
+          box-shadow: var(--btn-shadow-up);
+        }
+        .qd-category-toggle:hover {
+          background: black;
+          color: aliceblue;
+          border-radius: 0 4px 4px 0;
+        }
+        .qd-category-toggle:active {
+          box-shadow: var(--btn-shadow-down);
+        }
+      }
+      .category-menu {
+        position: absolute;
+        top: 38px;
+        right: 0px;
+        background: rgb(37, 37, 37);;
+        color: aliceblue;
+        width: 80%;
+        box-shadow: var(--btn-shadow-up);
+        border-radius: 5px;
+        margin: 0 0 0 20%;
+        cursor: default;
+        z-index: 3;
         text-align: center;
-        width: 100%;
-        align-content: center;
-        border-radius: 4px 0 0 4px;
-        box-shadow: var(--btn-shadow-up);
-        /* text-shadow: 0 0 3px aliceblue; */
-      }
-      .qd-category-toggle {
-        background: none;
-        border: none;
-        border-radius: 0 4px 4px 0;
-        margin: 0 0 0 auto;
-        padding: 0 10px;
-        font-size: 1rem;
-        box-shadow: var(--btn-shadow-up);
-      }
-      .qd-category-toggle:hover {
-        background: black;
-        color: aliceblue;
-        border-radius: 0 4px 4px 0;
-      }
-      .qd-category-toggle:active {
-        box-shadow: var(--btn-shadow-down);
+        .category-item {
+          display: block;
+          padding: 1px 0;
+          background: none;
+          border: none;
+          color: aliceblue;
+          width: 100%;
+        }
+        button:hover {
+          background: #45494970;
+        }
+        button:first-of-type:hover {
+          border-radius: 5px 5px 0px 0px;
+        }
+        button:last-of-type:hover {
+          border-radius: 0px 0px 5px 5px;
+        }
       }
     }
-    .category-menu {
-      position: absolute;
-      top: 38px;
-      right: 0px;
-      background: rgb(37, 37, 37);;
+
+    .qd-status, .qd-game-status {
+      border: 1px solid black;
+    }
+
+    .qd-game-status::before {
+      content: "in "
+    }
+    .qd-game-status:hover::before {
+      content: "View ";
+    }
+    .qd-game-status:hover {
+      background: black;
       color: aliceblue;
-      width: 80%;
-      box-shadow: var(--btn-shadow-up);
-      border-radius: 5px;
-      margin: 0 0 0 20%;
-      cursor: default;
-      z-index: 3;
-      text-align: center;
-      .category-item {
-        display: block;
-        padding: 1px 0;
-        background: none;
-        border: none;
+    }
+    .qd-game-status:active {
+      box-shadow: var(--btn-shadow-down);
+    }
+
+    .game-dropdown {
+      hr {
+        margin: 3px 0;
+        border: 1px solid black;
+      }
+      p {
+        margin: 0;
+        background: var(--main-color-1);
+        width: 100%;
+        color: aliceblue;
+      }
+      .assigned-list {
         color: aliceblue;
         width: 100%;
+        position: relative;
+        max-height: 220px;
+        overflow-y: auto;
+        scrollbar-width: thin;
+        scrollbar-color: var(--main-color-1) black;
+        .assigned-game {
+          position: relative;
+          width: 100%;
+          padding: 5px;
+          border-radius: 5px;
+          button {
+            background: none;
+            border: none;
+            color: inherit;
+            width: 100%;
+          }
+          .gq-remove {
+            position: absolute;
+            top: 3px;
+            right: 3px;
+            text-align: right;
+            width: auto;
+            font-size: 0.8rem;
+          }
+          .gq-remove:hover {
+            color: rgb(255, 53, 53);
+          }
+          .qd-gq-status {
+            text-align: left;
+            font-size: 0.8rem;
+            .status-tag {
+              box-shadow: var(--btn-shadow-up);
+              border: 1px solid black;
+              border-radius: 5px;
+              padding: 1px 6px;
+              color: black;
+            }
+          }
+          .qd-gq-game {
+            margin: 0 0 0 auto;
+            width: 85%;
+            font-style: italic;
+            text-align: left;
+          }
+        }
+        .assigned-game:hover {
+          background: #353939;
+          box-shadow: inset 0 0 3px black;
+        }
       }
-      button:hover {
-        background: #45494970;
-      }
-      button:first-of-type:hover {
-        border-radius: 5px 5px 0px 0px;
-      }
-      button:last-of-type:hover {
-        border-radius: 0px 0px 5px 5px;
+      .dropdown-element {
+        position: relative;
+        .qd-assign-game {
+          display: flex;
+          padding: 0;
+          background: aliceblue;
+          .qd-game-name {
+            padding: 5px;
+            text-align: center;
+            width: 100%;
+            align-content: center;
+            border-radius: 4px 0 0 4px;
+            box-shadow: var(--btn-shadow-up);
+          }
+          .qd-game-toggle {
+            background: none;
+            border: none;
+            border-radius: 0 4px 4px 0;
+            margin: 0 0 0 auto;
+            padding: 0 10px;
+            font-size: 1rem;
+            box-shadow: var(--btn-shadow-up);
+          }
+          .qd-game-toggle:hover {
+            background: black;
+            color: aliceblue;
+            border-radius: 0 4px 4px 0;
+          }
+          .qd-game-toggle:active {
+            box-shadow: var(--btn-shadow-down);
+          }
+        }
+        .assign-game-menu {
+          position: absolute;
+          top: 34px;
+          right: 0px;
+          background: rgb(37, 37, 37);
+          color: aliceblue;
+          width: 85%;
+          box-shadow: var(--btn-shadow-up);
+          border-radius: 5px;
+          margin: 0 0 0 20%;
+          cursor: default;
+          z-index: 3;
+          text-align: center;
+          max-height: 200px;
+          overflow-y: auto;
+          scrollbar-width: none;
+          .sticky-search {
+            position: sticky;
+            width: 100%;
+            padding: 0 5px;
+            top: 0px;
+            margin-bottom: 5px;
+          }
+          .sticky-search:active {
+            border: none;
+          }
+          .game-item {
+            display: block;
+            padding: 1px 5px;
+            background: none;
+            border: none;
+            color: aliceblue;
+            width: 100%;
+          }
+          button:hover {
+            background: #45494970;
+          }
+          button:last-of-type:hover {
+            border-radius: 0px 0px 5px 5px;
+          }
+        }
       }
     }
+
     .qd-return {
       border: none;
       margin-top: 30px;


### PR DESCRIPTION
## Description
Created GameDropdown component and added to host/question/[id]
Displays list of games question is currently in and status in that game with option to remove from the game
Includes dropdown to add to a new game (on click), only games not added to currently are displayed

Add navigation between host/question/[id] and host/question/[id]/[gameId]

## Related Issue
#44 

## Motivation and Context
As a host, I want to add questions to and remove questions from games in order to build a game and populate from my database of questions. When I click on a question, I want to see at a glance what other games this question has been part of. I want to easily navigate between game-specific question management tools, and higher scope question edit tools.

## How Can This Be Tested?
Go to host/question/[id] for any question. Select games from the dropdown to add the question to. Display should update automatically. Click the 'X' to remove that question from the game.

Navigate to game to verify add/remove.

## Screenshots (if appropriate):
![image](https://github.com/alexberka/a-trivial-glance/assets/148516337/65723fb0-0277-48e5-8029-06930ec33e80)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
