### PR TITLE
Repair Question Link in Player Game Display

### DIFF
--- a/components/NavBarAuth.js
+++ b/components/NavBarAuth.js
@@ -98,6 +98,12 @@ export default function NavBarAuth() {
                   ))}
               </>
               )}
+              <Link
+                passHref
+                href={router.pathname.includes('/game/[id]') ? `/host/game/${router.query.id}` : '/host/games'}
+              >
+                <button type="button">Switch to Host View</button>
+              </Link>
             </>
           )}
           <hr />

--- a/components/QuestionDetails.js
+++ b/components/QuestionDetails.js
@@ -126,7 +126,8 @@ export default function QuestionDetails({
             : 'Last Used: Never'}
         </p>
         )}
-        {questionObj.gameQuestionId ? (
+        {host
+        && (questionObj.gameQuestionId ? (
           <>
             <p className={`qd-btn qd-status status-${questionObj.status}`}>
               {questionObj.status.toUpperCase()}
@@ -146,11 +147,11 @@ export default function QuestionDetails({
           <>
             <GameDropdown />
           </>
-        )}
+        ))}
         {/* If in player view, include button to return to current game */}
         {!host
         && (
-          <Link passHref href="/game">
+          <Link passHref href={`/game/${questionObj.game.firebaseKey}`}>
             <button type="button" className="qd-return qd-btn">
               RETURN TO GAME
             </button>

--- a/pages/question/[id]/[gameQuestionId].js
+++ b/pages/question/[id]/[gameQuestionId].js
@@ -1,23 +1,27 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import { useRouter } from 'next/router';
 import React, { useEffect, useState } from 'react';
-import QuestionDetails from '../../components/QuestionDetails';
-import { getQuestionById } from '../../api/mergedData';
+import { getFullGameQuestion } from '../../../api/mergedData';
+import QuestionDetails from '../../../components/QuestionDetails';
 
-export default function ReviewQuestion() {
+export default function ReviewGameQuestion() {
   const router = useRouter();
   const [question, setQuestion] = useState({});
 
   useEffect(() => {
-    getQuestionById(router.query.id)
+    getFullGameQuestion(router.query.gameQuestionId)
       .then((q) => {
         // Only allow player access to view questions that are closed
-        if (q.status === 'closed') {
+        if (q.game.status === 'live' && (q.status === 'closed' || q.status)) {
           setQuestion(q);
         } else {
           // Otherwise, redirect to '/game'
           window.alert('Question Not Available');
-          router.push('/game');
+          if (q.game.status !== 'live') {
+            router.push('/games');
+          } else {
+            router.push(`/game/${q.game.firebaseKey}`);
+          }
         }
       });
   }, []);


### PR DESCRIPTION
## Description
Moved /question/[id] functionality to /question/[id]/[gameQuestionId]
Clicking on a question in the player game display takes player to this question details page
If the gameQuestion is closed, reroutes to the game, if game is closed, reroutes to /games

## Related Issue
NA

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Can This Be Tested?
From /game/[id], click one of the question cards in "Past Questions"
Question Details page appears similar to one below
Only button should be the "Return to Game" button, which routes back to the game

## Screenshots (if appropriate):
![image](https://github.com/alexberka/a-trivial-glance/assets/148516337/ded1ad5d-cf0e-485a-8fdb-b288b01c16d5)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
