### PR TITLE
Fix Memory Leak Warning

### DIFF
--- a/components/forms/CategoryDropdown.js
+++ b/components/forms/CategoryDropdown.js
@@ -17,7 +17,12 @@ export default function CategoryDropdown({ questionId, selectedCategoryId, form 
 
   // Categories only retrieved on component mount
   useEffect(() => {
-    getCategories().then(setCategories);
+    let mounted = true;
+    getCategories().then((data) => {
+      if (mounted) { setCategories(data); }
+    });
+
+    return () => { (mounted = false); };
   }, []);
 
   // Toggles menu open and closed

--- a/pages/games.js
+++ b/pages/games.js
@@ -6,7 +6,10 @@ export default function PlayerGameSelect() {
   const [openGames, setOpenGames] = useState([]);
 
   useEffect(() => {
-    getLiveGames().then(setOpenGames);
+    let mounted = true;
+    getLiveGames().then((data) => { if (mounted) { setOpenGames(data); } });
+
+    return () => { (mounted = false); };
   }, []);
 
   return (

--- a/pages/host/game/[id].js
+++ b/pages/host/game/[id].js
@@ -1,5 +1,5 @@
 /* eslint-disable react-hooks/exhaustive-deps */
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/router';
 import GameDisplay from '../../../components/GameDisplay';
 import { getFullGameData } from '../../../api/mergedData';
@@ -9,6 +9,13 @@ export default function ManageGame() {
   const [gameData, setGameData] = useState();
   const router = useRouter();
   const { user } = useAuth();
+  const isMounted = useRef(false);
+
+  useEffect(() => {
+    isMounted.current = true;
+
+    return () => { (isMounted.current = false); };
+  }, []);
 
   const confirmAccess = (gCheck) => {
     // If non-host user is attempting to access the host panel for a game they did not create
@@ -16,7 +23,7 @@ export default function ManageGame() {
     // then redirect user to games page
     if (!gCheck.uid || gCheck.uid !== user.uid) {
       router.push('/host/games');
-    } else {
+    } else if (isMounted.current) {
       // Otherwise, set that question as 'question' state
       setGameData(gCheck);
     }

--- a/pages/host/game/edit/[id].js
+++ b/pages/host/game/edit/[id].js
@@ -9,7 +9,12 @@ export default function EditGame() {
   const router = useRouter();
 
   useEffect(() => {
-    getGameById(router.query.id).then(setGame);
+    let mounted = true;
+    getGameById(router.query.id).then((data) => {
+      if (mounted) { setGame(data); }
+    });
+
+    return () => { (mounted = false); };
   }, []);
 
   return (

--- a/pages/host/games.js
+++ b/pages/host/games.js
@@ -10,7 +10,12 @@ export default function HostGames() {
   const { user } = useAuth();
 
   useEffect(() => {
-    getGameCardsData(user.uid).then(setGames);
+    let mounted = true;
+    getGameCardsData(user.uid).then((data) => {
+      if (mounted) { setGames(data); }
+    });
+
+    return () => { (mounted = false); };
   }, []);
 
   return (

--- a/pages/host/question/[id].js
+++ b/pages/host/question/[id].js
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import QuestionDetails from '../../../components/QuestionDetails';
 import { useAuth } from '../../../utils/context/authContext';
 import QuestionForm from '../../../components/forms/QuestionForm';
@@ -12,6 +12,13 @@ export default function ManageQuestion() {
   const [editing, setEditing] = useState(false);
   const router = useRouter();
   const { user } = useAuth();
+  const isMounted = useRef(false);
+
+  useEffect(() => {
+    isMounted.current = true;
+
+    return () => { (isMounted.current = false); };
+  }, []);
 
   // 'qCheck' is the question object to check before setting it as the 'question' state
   const confirmAccess = (qCheck) => {
@@ -20,7 +27,7 @@ export default function ManageQuestion() {
     // then redirect user to welcome page
     if (!qCheck.uid || qCheck.uid !== user.uid) {
       router.push('/');
-    } else {
+    } else if (isMounted.current) {
       // Otherwise, set that question as 'question' state
       setQuestion(qCheck);
     }
@@ -36,7 +43,7 @@ export default function ManageQuestion() {
   // 'toggle' can be set to false to bypass toggle of 'editing' state
   const onUpdate = (toggle = true) => {
     getQuestionById(router.query.id)
-      .then(setQuestion)
+      .then((data) => { if (isMounted.current) { setQuestion(data); } })
       .then(() => { if (toggle) { toggleEdit(); } });
   };
 

--- a/pages/host/question/[id]/[gameQuestionId].js
+++ b/pages/host/question/[id]/[gameQuestionId].js
@@ -1,5 +1,5 @@
 /* eslint-disable react-hooks/exhaustive-deps */
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/router';
 import QuestionDetails from '../../../../components/QuestionDetails';
 import { getFullGameQuestion } from '../../../../api/mergedData';
@@ -7,6 +7,13 @@ import { getFullGameQuestion } from '../../../../api/mergedData';
 export default function ManageGameQuestion() {
   const [question, setQuestion] = useState({});
   const router = useRouter();
+  const isMounted = useRef(false);
+
+  useEffect(() => {
+    isMounted.current = true;
+
+    return () => { (isMounted.current = false); };
+  }, []);
 
   const onUpdate = () => {
     getFullGameQuestion(router.query.gameQuestionId).then(setQuestion);

--- a/pages/host/questions.js
+++ b/pages/host/questions.js
@@ -10,7 +10,12 @@ export default function HostQuestions() {
   const { user } = useAuth();
 
   useEffect(() => {
-    getQuestionsByHost(user.uid).then(setQuestions);
+    let mounted = true;
+    getQuestionsByHost(user.uid).then((data) => {
+      if (mounted) { setQuestions(data); }
+    });
+
+    return () => { (mounted = false); };
   }, []);
 
   return (

--- a/pages/question/[id]/[gameQuestionId].js
+++ b/pages/question/[id]/[gameQuestionId].js
@@ -9,10 +9,11 @@ export default function ReviewGameQuestion() {
   const [question, setQuestion] = useState({});
 
   useEffect(() => {
+    let mounted = true;
     getFullGameQuestion(router.query.gameQuestionId)
       .then((q) => {
         // Only allow player access to view questions that are closed
-        if (q.game.status === 'live' && (q.status === 'closed' || q.status)) {
+        if (q.game.status === 'live' && (q.status === 'closed' || q.status === 'released') && mounted) {
           setQuestion(q);
         } else {
           // Otherwise, redirect to '/game'
@@ -24,6 +25,8 @@ export default function ReviewGameQuestion() {
           }
         }
       });
+
+    return () => { (mounted = false); };
   }, []);
 
   return (


### PR DESCRIPTION
## Description
Added mounting check (either as `isMounted` useRef or local variable `mounted`) to prevent attempting to set state variables in components and pages with data retrieved from API calls if the component has already unmounted. This avoids the "memory leak" warning in devtools.

Fixed bug which allowed all users to view any question from an live game, even if question status is open or unused.

## Related Issue
NA

## Motivation and Context
Memory leak did not affect functionality

With gameQuestion bug, player users could directly access a view page via url manipulation if they had the questionId and gameQuestionId, revealing the answer prior to closing of the question.

## How Can This Be Tested?
Open dev tools. Navigate site and attempt to move between pages faster than API calls can be completed. No memory leak warnings should appear in console.

Attempt to access /question/[id]/[gameQuestionId] for a question that is not closed or released. Site should redirect prior to data load.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
