### PR TITLE
Players Submit Responses to Questions

### DIFF
--- a/api/mergedData.js
+++ b/api/mergedData.js
@@ -7,7 +7,8 @@ import {
   deleteGameQuestion,
 } from './gameQuestionsData';
 import { getQuestionByIdNoCat, getQuestionsByHostNoCats, getQuestionsNoCats } from './questionsData';
-import { deleteTeam, getTeamsByGameId } from './teamsData';
+import { getResponsesByTeamId } from './responsesData';
+import { deleteTeam, getTeamsByGameId, getTeamsByUid } from './teamsData';
 
 const getQuestions = async () => {
   const questions = await getQuestionsNoCats();
@@ -63,7 +64,7 @@ const getFullGameQuestion = async (gameQuestionId) => {
 const getFullGameData = async (gameId) => {
   const gameInfo = await getGameById(gameId);
   const questions = await getGameQuestions(gameId);
-  return { ...gameInfo, questions };
+  return { ...gameInfo, questions: questions.sort((a, b) => b.timeOpened.localeCompare(a.timeOpened)) };
 };
 
 const getGameCardsData = async (uid) => {
@@ -71,6 +72,14 @@ const getGameCardsData = async (uid) => {
   const promisedGQs = gamesInfo.map((g) => getGameQuestionsByGame(g.firebaseKey));
   const realGQs = await Promise.all(promisedGQs);
   return gamesInfo.map((g, index) => ({ ...g, size: realGQs[index].length }));
+};
+
+const getTeamData = async (uid, gameId) => {
+  const userTeams = await getTeamsByUid(uid);
+  const gameTeam = userTeams.find((t) => t.gameId === gameId);
+  const teamResponses = await getResponsesByTeamId(gameTeam.firebaseKey);
+  // console.warn(gameTeam, teamResponses);
+  return { ...gameTeam, responses: teamResponses };
 };
 
 const deleteGame = async (firebaseKey) => {
@@ -96,6 +105,7 @@ export {
   getFullGameQuestion,
   getFullGameData,
   getGameCardsData,
+  getTeamData,
   deleteGame,
   resetAllQuestions,
 };

--- a/api/responsesData.js
+++ b/api/responsesData.js
@@ -1,0 +1,73 @@
+import { clientCredentials } from '../utils/client';
+
+const ENDPOINT = clientCredentials.databaseURL;
+
+const getResponsesByTeamId = (teamId) => new Promise((resolve, reject) => {
+  fetch(`${ENDPOINT}/responses.json?orderBy="teamId"&equalTo="${teamId}"`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application.json',
+    },
+  })
+    .then((response) => response.json())
+    .then((data) => resolve(data ? Object.values(data) : []))
+    .catch(reject);
+});
+
+const getResponsesByGameQuestionId = (gameQuestionId) => new Promise((resolve, reject) => {
+  fetch(`${ENDPOINT}/responses.json&orderBy="gameQuestionId"&equalTo="${gameQuestionId}"`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application.json',
+    },
+  })
+    .then((response) => response.json())
+    .then((data) => resolve(data ? Object.values(data) : []))
+    .catch(reject);
+});
+
+const createResponse = (payload) => new Promise((resolve, reject) => {
+  fetch(`${ENDPOINT}/responses.json`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application.json',
+    },
+    body: JSON.stringify(payload),
+  })
+    .then((response) => response.json())
+    .then(resolve)
+    .catch(reject);
+});
+
+const updateResponse = (payload) => new Promise((resolve, reject) => {
+  fetch(`${ENDPOINT}/responses/${payload.firebaseKey}.json`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application.json',
+    },
+    body: JSON.stringify(payload),
+  })
+    .then((response) => response.json())
+    .then(resolve)
+    .catch(reject);
+});
+
+const deleteResponse = (firebaseKey) => new Promise((resolve, reject) => {
+  fetch(`${ENDPOINT}/responses/${firebaseKey}.json`, {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application.json',
+    },
+  })
+    .then((response) => response.json())
+    .then(resolve)
+    .catch(reject);
+});
+
+export {
+  getResponsesByTeamId,
+  getResponsesByGameQuestionId,
+  createResponse,
+  updateResponse,
+  deleteResponse,
+};

--- a/components/panels/PlayerResponsePanel.js
+++ b/components/panels/PlayerResponsePanel.js
@@ -1,0 +1,70 @@
+import React, { useState } from 'react';
+import { Form } from 'react-bootstrap';
+import PropTypes from 'prop-types';
+import { createResponse, updateResponse } from '../../api/responsesData';
+
+export default function PlayerResponsePanel({ responseObj, onUpdate, questionStatus }) {
+  const [formInput, setFormInput] = useState(responseObj);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormInput((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    const payload = { ...formInput, grade: 'NA', timeSubmitted: new Date().toISOString() };
+    if (responseObj.firebaseKey) {
+      updateResponse(payload);
+    } else {
+      createResponse(payload).then(({ name }) => {
+        updateResponse({ firebaseKey: name }).then(() => onUpdate());
+      });
+    }
+  };
+
+  return (
+    <div className="response-container">
+      <div className="response-tab">
+        <p className={`${questionStatus === 'open' && !responseObj.firebaseKey && ('blinking')}`}>
+          {responseObj.firebaseKey || questionStatus !== 'open' ? 'Your Answer' : 'Submit Answer'}
+        </p>
+        <div className="tab-shadow-cover" />
+      </div>
+      <div className="response-panel">
+        {responseObj.firebaseKey || questionStatus !== 'open' ? (
+          <>
+            <p className={responseObj.response ? 'player-response' : ''}>{responseObj.response || (<i>No Response</i>)}</p>
+            {questionStatus === 'released' && responseObj.grade !== 'NA' && (<span>{responseObj.grade}</span>)}
+          </>
+        ) : (
+          <Form onSubmit={handleSubmit}>
+            <input
+              className="response-input"
+              name="response"
+              type="text"
+              placeholder="Type answer..."
+              value={formInput.response || ''}
+              onChange={handleChange}
+              onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); } }}
+            />
+            <button type="submit" disabled={formInput.response === ''}>Submit</button>
+            <p>Warning: Answers are final and may not be edited once submitted</p>
+          </Form>
+        )}
+      </div>
+    </div>
+  );
+}
+
+PlayerResponsePanel.propTypes = {
+  responseObj: PropTypes.shape({
+    firebaseKey: PropTypes.string,
+    teamId: PropTypes.string,
+    gameQuestionId: PropTypes.string,
+    response: PropTypes.string,
+    grade: PropTypes.string,
+  }).isRequired,
+  onUpdate: PropTypes.func.isRequired,
+  questionStatus: PropTypes.string.isRequired,
+};

--- a/components/panels/TeamPanel.js
+++ b/components/panels/TeamPanel.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import TeamForm from './forms/TeamForm';
+import TeamForm from '../forms/TeamForm';
 
 export default function TeamPanel({ teamObj, onUpdate }) {
   const [editing, setEditing] = useState(false);
@@ -12,13 +12,13 @@ export default function TeamPanel({ teamObj, onUpdate }) {
 
   return (
     <div className="team-panel">
-      {editing && (
-        <TeamForm teamObj={teamObj} onUpdate={handleToggle} />
-      )}
-      <p>{teamObj?.name}</p>
       <button type="button" onClick={handleToggle} disabled={editing}>
         Edit
       </button>
+      {editing && (
+        <TeamForm teamObj={teamObj} onUpdate={handleToggle} />
+      )}
+      <span>{teamObj?.name}</span>
     </div>
   );
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -11,7 +11,7 @@ body {
 }
 
 :root {
-  --main-color-1: #454949;
+  --main-color-1: #555959;
   --btn-shadow-up: inset 0 0 5px black, inset 2px 2px 5px 0 #e5e9e975, 2px 2px 3px black;
   --btn-shadow-down: inset 0px 0px 7px black, inset 2px 2px 7px 0 #e5e9e975, 1px 1px 2px black;
 }
@@ -27,6 +27,49 @@ a {
 
 body {
   background-color: var(--main-color-1);
+}
+
+.bg-positive-top {
+  position: fixed;
+  z-index: -3;
+  right: 0;
+  top: 0;
+  width: 300px;
+  height: 100px;
+  background: linear-gradient(235deg, black, var(--main-color-1) 43%);
+}
+.bg-negative-top {
+  position: fixed;
+  z-index: -2;
+  right: 0;
+  top: 0;
+  width: 600px;
+  height: 200px;
+  background: var(--main-color-1);
+  border-radius: 50%;
+}
+.bg-positive-bottom {
+  position: fixed;
+  z-index: -3;
+  left: 0;
+  bottom: 0;
+  width: 300px;
+  height: 100px;
+  background: linear-gradient(-235deg, black, var(--main-color-1) 43%);
+}
+.bg-negative-bottom {
+  position: fixed;
+  z-index: -2;
+  left: 0;
+  bottom: 0;
+  width: 600px;
+  height: 200px;
+  background: var(--main-color-1);
+  border-radius: 50%;
+}
+
+input:focus {
+  outline: none;
 }
 
 .nav-menu {
@@ -210,6 +253,13 @@ body {
     top: -188px;
     font-size: 75px;
   }
+}
+.title-watermark {
+  z-index: -2;
+  color: var(--main-color-1);
+  transform: rotate(17deg) scale(0.7);
+  left: 5px;
+  bottom: 80px;
 }
 
 .page-header {
@@ -899,19 +949,22 @@ body {
 
 .team-panel {
   position: fixed;
-  bottom: 0px;
+  bottom: -5px;
   right: 5%;
   z-index: 5;
-  padding: 8px 5px 15px 5px;
+  padding: 8px 5px 15px 10px;
+  min-height: 50px;
+  max-width: 25%;
   background: #353939;
   border-radius: 5px 5px 0 0;
   color: aliceblue;
   box-shadow: 0 0 3px 1px black;
-  button, p  {
-    display: inline-block;
+  button  {
+    display: inline;
     margin: 0 6px;
   }
   button {
+    float: right;
     font-size: 0.8rem;
     box-shadow: var(--btn-shadow-up);
     color: aliceblue;
@@ -924,7 +977,96 @@ body {
     box-shadow: var(--btn-shadow-down);
     color: rgba(240, 248, 255, 0.699);
   }
-  p {
+  span {
     pointer-events: none;
   }
+}
+
+.response-container {
+  position: fixed;
+  top: calc(100% + 5px);
+  height: 32%;
+  left: 18%;
+  width: 50%;
+  color: aliceblue;
+  z-index: 5;
+  transition: 1s;
+  .response-panel {
+    height: 100%;
+    padding: 15px 10px 10px 10px;
+    background: #353939;
+    border-radius: 5px 5px 0 0;
+    z-index: 1;
+    box-shadow: 0 0 3px 1px black;
+    input {
+      width: 100%;
+      border-radius: 5px;
+      background: #353939;
+      color: aliceblue;
+      padding: 5px 10px;
+      box-shadow: inset 0 0 4px black;
+      border: none;
+      }
+    button {
+      float: right;
+      font-size: 0.8rem;
+      box-shadow: var(--btn-shadow-up);
+      color: aliceblue;
+      border-radius: 5px;
+      background: var(--main-color-1);
+      border: none;
+      padding: 4px 8px;
+      margin: 3px 0;
+    }
+    button:disabled {
+      visibility: hidden;
+    }
+    p {
+      padding: 2px 4px;
+      color: #c5c9c9;
+      font-size: 0.8rem;
+      font-style: italic;
+    }
+    .player-response {
+      font-size: 1.5rem;
+      padding: 0 10px;
+    }
+  }
+  .response-tab {
+    position: absolute;
+    top: -50px;
+    right: 20px;
+    height: 50px;
+    padding: 8px 5px 10px 5px;
+    border-radius: 5px 5px 0 0;
+    background: #353939;
+    box-shadow: 0 0 3px 1px black;
+    p {
+      margin: 0 6px;
+      cursor: default;
+      }
+    .blinking {
+      animation: blinking 3s linear infinite;
+    }
+    .tab-shadow-cover {
+      background: inherit;
+      position: absolute;
+      bottom: -10px;
+      left: -5%;
+      width: 110%;
+      height: 10px;
+      pointer-events: none;
+    }
+  }
+}
+    
+@keyframes blinking {
+  50% {
+    opacity: 0.5;
+  }
+}
+
+.response-container:hover {
+  position: fixed;
+  top: 70%;
 }

--- a/utils/ViewDirector.js
+++ b/utils/ViewDirector.js
@@ -18,10 +18,21 @@ const ViewDirectorBasedOnUserAuthStatus = ({ component: Component, pageProps }) 
   if (user) {
     return (
       <>
+        <div className="bg-positive-top" />
+        <div className="bg-negative-top" />
+        <div className="bg-positive-bottom" />
+        <div className="bg-negative-bottom" />
         {router.pathname !== '/' && (<NavBarAuth />)}
         <div className="container">
           <Component {...pageProps} />
         </div>
+        {router.pathname !== '/' && (
+          <div className="welcome-title title-watermark">
+            <h3>A</h3>
+            <h1>TRIVIAL</h1>
+            <h2>GLANCE</h2>
+          </div>
+        )}
       </>
     );
   }


### PR DESCRIPTION
## Description
Created responsesData.js with response API calls and PlayerResponsePanel component
When on a game/[id] page, PlayerResponsePanel appears as tab along bottom of screen. Hovering displays a response form (if the question is open and unanswered) or the player's response to that question (if closed, released, or already answered)

Questions from getFullGameData now sort in reverse order of release

Added logic gates to only update state on game/[id] when one of a handful of changes have been made

Added background styling

## Related Issue
#57 

## Motivation and Context
As a player user, I want an interface through which to submit answers to questions.

## How Can This Be Tested?
As a player user, navigate to the game/[id] page of a live game. If any questions have been opened, the PlayerResponsePanel should display either "Submit Answer" or "View Answer". When on an open, unanswered question. Type in an answer and click submit (button only when response field isn't vacant, submit disabled for press of 'Enter' key to avoid accidental submission, button must be pressed). Tab will then display player answer for that question.

Check firebase for response entity creation

## Screenshots (if appropriate):
![image](https://github.com/alexberka/a-trivial-glance/assets/148516337/bd5c269c-b30a-43f5-ae03-9c7f957ebba8)
![image](https://github.com/alexberka/a-trivial-glance/assets/148516337/992ef869-5d4c-4f59-9bb5-497caa216b13)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
