### PR TITLE
Host drag and drop + styling

### DIFF
--- a/api/mergedData.js
+++ b/api/mergedData.js
@@ -111,9 +111,13 @@ const deleteGame = async (firebaseKey) => {
   const teamsToDelete = await getTeamsByGameId(firebaseKey);
   const deleted = gqToDelete.map((gq) => deleteGameQuestion(gq.firebaseKey));
   deleted.concat(teamsToDelete.map((t) => deleteTeam(t.firebaseKey)));
-  console.warn(gqToDelete.length, teamsToDelete.length, deleted.length);
   await Promise.all(deleted);
   await deleteGameOnly(firebaseKey);
+};
+
+const releaseMultipleQuestions = async (questions) => {
+  const releasePromises = questions.map((q) => updateGameQuestion({ firebaseKey: q.gameQuestionId, status: 'released' }));
+  await Promise.all(releasePromises);
 };
 
 const resetAllQuestions = async (questions) => {
@@ -145,6 +149,7 @@ export {
   getGameResponses,
   getQuestionResponses,
   deleteGame,
+  releaseMultipleQuestions,
   resetAllQuestions,
   resetSingleQuestion,
 };

--- a/components/GameDisplay.js
+++ b/components/GameDisplay.js
@@ -1,15 +1,23 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Image } from 'react-bootstrap';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import QuestionCard from './QuestionCard';
-import { deleteGame, resetAllQuestions } from '../api/mergedData';
+import { deleteGame, releaseMultipleQuestions, resetAllQuestions } from '../api/mergedData';
 import { updateGame } from '../api/gameData';
 import { updateGameQuestion } from '../api/gameQuestionsData';
+import { updateQuestion } from '../api/questionsData';
 
+const droppingReset = {
+  unused: false,
+  open: false,
+  closed: false,
+  released: false,
+};
 // 'questions' contains questions for game with attached category objects
 export default function GameDisplay({ game, host, onUpdate }) {
+  const [dropping, setDropping] = useState(droppingReset);
   const router = useRouter();
 
   const display = {
@@ -34,7 +42,7 @@ export default function GameDisplay({ game, host, onUpdate }) {
     }
   };
 
-  const handleStatus = (e) => {
+  const handleGameStatus = (e) => {
     const payload = { firebaseKey: game.firebaseKey };
     if (e.target.id === 'toggle') {
       payload.dateLive = new Date().toISOString();
@@ -48,7 +56,7 @@ export default function GameDisplay({ game, host, onUpdate }) {
       payload.status = 'unused';
     }
     updateGame(payload).then(() => {
-      if (payload.status === 'closed' && display.openQ.firebaseKey) {
+      if (payload.status === 'closed' && display.openQ?.firebaseKey) {
         updateGameQuestion({ firebaseKey: display.openQ.gameQuestionId, status: 'closed' }).then(onUpdate);
       } else {
         onUpdate();
@@ -57,16 +65,91 @@ export default function GameDisplay({ game, host, onUpdate }) {
   };
 
   const handleQuestionStatus = (e) => {
+    e.preventDefault();
     if (e.target.id === 'reset-questions') {
       if (window.confirm('Are you sure you want to reset all questions in this game? Timestamps will be erased and all responses deleted.')) {
         resetAllQuestions(game.questions).then(onUpdate);
       }
+    } else if (e.target.id === 'close-question') {
+      updateGameQuestion({ firebaseKey: display.openQ.gameQuestionId, status: 'closed' }).then(onUpdate);
+    } else if (e.target.id === 'release-questions') {
+      releaseMultipleQuestions(display.closedQ).then(onUpdate);
+    }
+  };
+
+  const handleDrop = (e, code) => {
+    e.preventDefault();
+    const draggedQ = e.dataTransfer.getData('gameQuestionId');
+    if (e.target.id === 'drag-unused' || code === 'drag-unused') {
+      if (display.openQ?.gameQuestionId === draggedQ
+        || display.closedQ?.some((q) => q.gameQuestionId === draggedQ)
+        || display.releasedQ?.some((q) => q.gameQuestionId === draggedQ)) {
+        if (window.confirm('Are you sure you want to reset this question? Timestamp and responses will be lost.')) {
+          updateGameQuestion({ firebaseKey: draggedQ, status: 'unused', timeOpened: 'never' }).then(onUpdate);
+        }
+      }
+    } else if (e.target.id === 'drag-open' || code === 'drag-open') {
+      if (game.status === 'live') {
+        const questionObj = game.questions.find((q) => q.gameQuestionId === draggedQ);
+        // if there is no currently open question
+        if (!display.openQ) {
+          // if this question is currently unused
+          // OR it is closed or released and user agrees to reopen it
+          if (display.unusedQ?.some((q) => q.gameQuestionId === draggedQ)
+          || ((display.closedQ?.some((q) => q.gameQuestionId === draggedQ)
+            || display.releasedQ?.some((q) => q.gameQuestionId === draggedQ))
+          && window.confirm('Reopen Question?'))) {
+            updateGameQuestion({ firebaseKey: draggedQ, status: 'open', timeOpened: new Date().toISOString() })
+              .then(() => updateQuestion({ firebaseKey: questionObj.firebaseKey, lastUsed: new Date().toISOString() }))
+              .then(onUpdate);
+          }
+        } else if (draggedQ !== display.openQ.gameQuestionId
+        && window.confirm(`Another question is already open.\n\nClose and ${display.unusedQ?.some((q) => q.gameQuestionId === draggedQ) ? 'open' : 'reopen'} this question instead?`)) {
+          updateGameQuestion({ firebaseKey: display.openQ.gameQuestionId, status: 'closed' })
+            .then(() => updateGameQuestion({ firebaseKey: draggedQ, status: 'open', timeOpened: new Date().toISOString() }))
+            .then(() => updateQuestion({ firebaseKey: questionObj.firebaseKey, lastUsed: new Date().toISOString() }))
+            .then(onUpdate);
+        }
+      } else {
+        window.alert('Game must be live to open a question');
+      }
+    } else if (e.target.id === 'drag-closed' || code === 'drag-closed') {
+      if (game.status === 'live') {
+        if (display.openQ?.gameQuestionId === draggedQ) {
+          updateGameQuestion({ firebaseKey: draggedQ, status: 'closed' }).then(onUpdate);
+        } else if (display.releasedQ?.some((q) => q.gameQuestionId === draggedQ)) {
+          if (window.confirm('Hide answer from teams?')) {
+            updateGameQuestion({ firebaseKey: draggedQ, status: 'closed' }).then(onUpdate);
+          }
+        }
+      }
+    } else if (e.target.id === 'drag-released' || code === 'drag-released') {
+      if (game.status === 'live') {
+        if (display.closedQ?.some((q) => q.gameQuestionId === draggedQ)) {
+          updateGameQuestion({ firebaseKey: draggedQ, status: 'released' }).then(onUpdate);
+        } else if (display.openQ?.gameQuestionId === draggedQ) {
+          window.alert('Question must be closed first.');
+        }
+      }
+    }
+    setDropping(droppingReset);
+  };
+
+  const toggleDropHighlight = (e, code) => {
+    if ((e.target.id === 'drag-unused' || code === 'drag-unused')) {
+      setDropping((prev) => ({ ...prev, unused: !prev.unused }));
+    } else if ((e.target.id === 'drag-open' || code === 'drag-open') && game.status === 'live') {
+      setDropping((prev) => ({ ...prev, open: !prev.open }));
+    } else if ((e.target.id === 'drag-closed' || code === 'drag-closed') && game.status === 'live') {
+      setDropping((prev) => ({ ...prev, closed: !prev.closed }));
+    } else if ((e.target.id === 'drag-released' || code === 'drag-released') && game.status === 'live') {
+      setDropping((prev) => ({ ...prev, released: !prev.released }));
     }
   };
 
   return (
-    <div className="game-display">
-      <div className="gd-header">
+    <>
+      <div className="gd-header header">
         <div className="gd-title-box">
           <h1>{game.name}</h1>
           <h2>{game.location}</h2>
@@ -90,7 +173,7 @@ export default function GameDisplay({ game, host, onUpdate }) {
                   className={`gd-status-toggle${game.status === 'live' ? '-closed' : '-live'}`}
                   type="button"
                   id="toggle"
-                  onClick={handleStatus}
+                  onClick={handleGameStatus}
                 >
                   {game.status === 'live' ? 'Close Game' : 'Go Live'}
                 </button>
@@ -98,7 +181,7 @@ export default function GameDisplay({ game, host, onUpdate }) {
                   <button type="button" id="reset-questions" onClick={handleQuestionStatus}>Reset Questions</button>
                 )
                   : game.status !== 'unused' && (
-                  <button className="gd-status-reset" type="button" id="reset-game" onClick={handleStatus}>Reset Game</button>
+                  <button className="gd-status-reset" type="button" id="reset-game" onClick={handleGameStatus}>Reset Game</button>
                   )}
               </>
             )}
@@ -114,87 +197,137 @@ export default function GameDisplay({ game, host, onUpdate }) {
           )}
         </div>
       </div>
-      <div className="gd-container">
-        {host && (
-          <div className="gd-unused">
-            <h3>Unused</h3>
-            <div className="gd-fade-captive">
-              <div className="gd-card-container">
-                {display.unusedQ.map((q) => (<QuestionCard key={q.firebaseKey} questionObj={q} host={host} />))}
+      <div className="content">
+        <div className="gd-container">
+          {host && (
+            <div className="gd-unused">
+              <h3 draggable onDragStart={(e) => e.dataTransfer.setData('text', 'hey')}>Unused</h3>
+              <div className={`gd-fade-captive ${dropping.unused && 'unused-highlight'}`}>
+                <div
+                  id="drag-unused"
+                  className="gd-card-container"
+                  onDragOver={(e) => e.preventDefault()}
+                  onDragEnter={(e) => toggleDropHighlight(e, 'drag-unused')}
+                  onDragLeave={(e) => toggleDropHighlight(e, 'drag-unused')}
+                  onDrop={(e) => handleDrop(e, 'drag-unused')}
+                >
+                  {display.unusedQ.map((q) => (<QuestionCard key={q.firebaseKey} questionObj={q} host={host} dragThis />))}
+                </div>
+                <div className="gd-scroll-fade" />
               </div>
-              <div className="gd-scroll-fade" />
             </div>
-          </div>
-        )}
-        {host ? (
-          <div className="gd-open-host">
-            <h3>Open</h3>
-            <div className="gd-fade-captive">
-              <div className="gd-card-container">
-                {display.openQ && (<QuestionCard questionObj={display.openQ} host={host} />)}
-              </div>
-              <div className="gd-scroll-fade" />
-            </div>
-          </div>
-        ) : (
-          <div className="gd-open-player">
-            {/* Display open question, if any */}
-            {display.playerQ.length > 0 && (
-            <>
-              <div className="gd-open-tags">
-                <p className="gd-open-category" style={{ background: `${display.playerQ[0].category.color}` }}>
-                  {display.playerQ[0].category.name.toUpperCase()}
-                </p>
-                <p className={`gd-open-status status-${display.playerQ[0].status === 'open' ? 'open' : 'closed'}`}>
-                  {display.playerQ[0].status === 'open' ? 'OPEN' : 'CLOSED'}
-                </p>
-              </div>
-              {/* Calculate question number based on number of closed questions */}
-              <h2>
-                Question #{(display.openQ ? 1 : 0) + display.closedQ.length + display.releasedQ.length}
-              </h2>
-              <hr />
-              <div className="gd-open-question">
-                <p>{display.playerQ[0].question}</p>
-                {display.playerQ[0].image && (<Image className="gd-image" src={display.playerQ[0].image} />)}
-                {display.playerQ[0].status === 'released' && (
-                  <>
-                    <hr />
-                    <p>{display.playerQ[0].answer}</p>
-                  </>
+          )}
+          {host ? (
+            <div className="gd-open-closed-host">
+              <div className="gd-col-header">
+                <h3>Open</h3>
+                {display.openQ?.firebaseKey && (
+                  <button
+                    id="close-question"
+                    type="button"
+                    className="gd-close-q std-btn"
+                    onClick={handleQuestionStatus}
+                  >
+                    CLOSE
+                  </button>
                 )}
               </div>
-            </>
-            )}
-          </div>
-        )}
-        {host && (
-          <div className="gd-closed">
-            <h3>Closed</h3>
-            <div className="gd-fade-captive">
-              <div className="gd-card-container">
-                {display.closedQ.map((q) => (<QuestionCard key={q.firebaseKey} questionObj={q} host={host} />))}
+              <div className={`gd-fade-captive gd-fc-open ${dropping.open && 'open-highlight'}`}>
+                <div
+                  id="drag-open"
+                  className="gd-card-container"
+                  onDragOver={(e) => e.preventDefault()}
+                  onDragEnter={(e) => toggleDropHighlight(e, 'drag-open')}
+                  onDragLeave={(e) => toggleDropHighlight(e, 'drag-open')}
+                  onDrop={(e) => handleDrop(e, 'drag-open')}
+                >
+                  {display.openQ && (<QuestionCard questionObj={display.openQ} host={host} dragThis />)}
+                </div>
+                <div className="gd-scroll-fade" />
+              </div>
+              <div className="gd-col-header">
+                <h3>Closed</h3>
+                {display.closedQ.length > 0 && game.status === 'live' && (
+                  <button
+                    id="release-questions"
+                    type="button"
+                    className="gd-close-q std-btn"
+                    onClick={handleQuestionStatus}
+                  >
+                    {display.closedQ.length > 1 ? 'RELEASE ALL' : 'RELEASE'}
+                  </button>
+                )}
+              </div>
+              <div className={`gd-fade-captive gd-fc-closed ${dropping.closed && 'closed-highlight'}`}>
+                <div
+                  id="drag-closed"
+                  className="gd-card-container"
+                  onDragOver={(e) => e.preventDefault()}
+                  onDragEnter={(e) => toggleDropHighlight(e, 'drag-closed')}
+                  onDragLeave={(e) => toggleDropHighlight(e, 'drag-closed')}
+                  onDrop={(e) => handleDrop(e, 'drag-closed')}
+                >
+                  {display.closedQ.map((q) => (<QuestionCard key={q.firebaseKey} questionObj={q} host={host} dragThis />))}
+                </div>
+                <div className="gd-scroll-fade" />
+              </div>
+            </div>
+          ) : (
+            <div className="gd-open-player">
+              {/* Display open question, if any */}
+              {display.playerQ.length > 0 && (
+              <>
+                <div className="gd-open-tags">
+                  <p className="gd-open-category" style={{ background: `${display.playerQ[0].category.color}` }}>
+                    {display.playerQ[0].category.name.toUpperCase()}
+                  </p>
+                  <p className={`gd-open-status status-${display.playerQ[0].status === 'open' ? 'open' : 'closed'}`}>
+                    {display.playerQ[0].status === 'open' ? 'OPEN' : 'CLOSED'}
+                  </p>
+                </div>
+                {/* Calculate question number based on number of closed questions */}
+                <h2>
+                  Question #{(display.openQ ? 1 : 0) + display.closedQ.length + display.releasedQ.length}
+                </h2>
+                <hr />
+                <div className="gd-open-question">
+                  <p>{display.playerQ[0].question}</p>
+                  {display.playerQ[0].image && (<Image className="gd-image" src={display.playerQ[0].image} />)}
+                  {display.playerQ[0].status === 'released' && (
+                    <>
+                      <hr />
+                      <p>{display.playerQ[0].answer}</p>
+                    </>
+                  )}
+                </div>
+              </>
+              )}
+            </div>
+          )}
+          <div className="gd-released">
+            {/* Display closed question(s), if any */}
+            <h3>{host ? 'Answers Released' : 'Previous Questions'}</h3>
+            <div className={`gd-fade-captive ${dropping.released && 'released-highlight'}`}>
+              <div
+                id="drag-released"
+                className="gd-card-container"
+                onDragOver={host && ((e) => e.preventDefault())}
+                onDragEnter={host && ((e) => toggleDropHighlight(e, 'drag-released'))}
+                onDragLeave={host && ((e) => toggleDropHighlight(e, 'drag-released'))}
+                onDrop={host && ((e) => handleDrop(e, 'drag-released'))}
+              >
+                {host
+                  ? display.releasedQ.map((q) => (<QuestionCard key={q.firebaseKey} questionObj={q} host={host} dragThis={host} />))
+                  : display.playerQ
+                    .slice(1)
+                    ?.map((q) => (<QuestionCard key={q.firebaseKey} questionObj={q} host={host} dragThis={host} />))}
               </div>
               <div className="gd-scroll-fade" />
             </div>
-          </div>
-        )}
-        <div className="gd-released">
-          {/* Display closed question(s), if any */}
-          <h3>{host ? 'Released' : 'Previous Questions'}</h3>
-          <div className="gd-fade-captive">
-            <div className="gd-card-container">
-              {host
-                ? display.releasedQ.map((q) => (<QuestionCard key={q.firebaseKey} questionObj={q} host={host} />))
-                : display.playerQ
-                  .slice(1)
-                  ?.map((q) => (<QuestionCard key={q.firebaseKey} questionObj={q} host={host} />))}
-            </div>
-            <div className="gd-scroll-fade" />
           </div>
         </div>
       </div>
-    </div>
+    </>
   );
 }
 

--- a/components/NavBarAuth.js
+++ b/components/NavBarAuth.js
@@ -44,7 +44,7 @@ export default function NavBarAuth() {
         <div className="nav-expanded" onMouseLeave={closeNav}>
           {/* Construction of logo, directs to welcome page */}
           <Link passHref href="/">
-            <button type="button" className="nav-logo">
+            <button type="button" className="nav-logo logo">
               <p className="nav-logo-a">A</p>
               <p className="nav-logo-b">TRIVIAL</p>
               <p className="nav-logo-c">GLANCE</p>

--- a/components/QuestionCard.js
+++ b/components/QuestionCard.js
@@ -4,7 +4,7 @@ import Link from 'next/link';
 
 // 'questionObj' includes a single question object with associated category object
 // 'host' is a boolean that indicates whether user is in host view or not (defaults to false)
-export default function QuestionCard({ questionObj, host }) {
+export default function QuestionCard({ questionObj, host, dragThis }) {
   return (
     // If host is set to true, clicking the card will direct to the question's details page with host tools
     // Otherwise, clicking will direct to player view of question (/question/[id] redirects if question isn't closed)
@@ -12,7 +12,7 @@ export default function QuestionCard({ questionObj, host }) {
       passHref
       href={`${host ? '/host' : ''}/question/${questionObj.firebaseKey}/${questionObj.gameQuestionId ? questionObj.gameQuestionId : ''}`}
     >
-      <div className="q-card">
+      <div className="q-card" draggable={dragThis} onDragStart={(e) => e.dataTransfer.setData('gameQuestionId', questionObj.gameQuestionId)}>
         <div className="q-card-tags">
           <p className="q-category" style={{ background: `${questionObj.category.color}` }}>
             {questionObj.category.name.toUpperCase()}
@@ -59,8 +59,10 @@ QuestionCard.propTypes = {
     }),
   }).isRequired,
   host: PropTypes.bool,
+  dragThis: PropTypes.bool,
 };
 
 QuestionCard.defaultProps = {
   host: false,
+  dragThis: false,
 };

--- a/components/QuestionDetails.js
+++ b/components/QuestionDetails.js
@@ -173,22 +173,24 @@ export default function QuestionDetails({
                     Reset Question
                   </button>
                 )}
-                {questionObj.status === 'closed' && (
-                  <button type="button" onClick={handleStatus} value="release" className="qd-btn">
-                    Release Answer
-                  </button>
-                )}
-                {questionObj.status === 'released' && (
-                  <button type="button" onClick={handleStatus} value="unrelease" className="qd-btn">
-                    Hide Answer
-                  </button>
-                )}
                 {questionObj.game.status === 'live' && (
-                  <button type="button" onClick={handleStatus} className="qd-btn">
-                    {questionObj.status === 'unused' && 'Open Question'}
-                    {questionObj.status === 'open' && 'Close Question'}
-                    {(questionObj.status === 'closed' || questionObj.status === 'released') && 'Reopen Question'}
-                  </button>
+                  <>
+                    {questionObj.status === 'closed' && (
+                      <button type="button" onClick={handleStatus} value="release" className="qd-btn">
+                        Release Answer
+                      </button>
+                    )}
+                    {questionObj.status === 'released' && (
+                      <button type="button" onClick={handleStatus} value="unrelease" className="qd-btn">
+                        Hide Answer
+                      </button>
+                    )}
+                    <button type="button" onClick={handleStatus} className="qd-btn">
+                      {questionObj.status === 'unused' && 'Open Question'}
+                      {questionObj.status === 'open' && 'Close Question'}
+                      {(questionObj.status === 'closed' || questionObj.status === 'released') && 'Reopen Question'}
+                    </button>
+                  </>
                 )}
               </>
             ) : (

--- a/components/Signin.js
+++ b/components/Signin.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Button } from 'react-bootstrap';
 import { useRouter } from 'next/router';
 import { signIn } from '../utils/auth';
 
@@ -12,21 +11,30 @@ function Signin() {
   };
 
   return (
-    <div
-      className="text-center d-flex flex-column justify-content-center align-content-center"
-      style={{
-        height: '90vh',
-        padding: '30px',
-        maxWidth: '400px',
-        margin: '0 auto',
-      }}
-    >
-      <h1>Hi there!</h1>
-      <p>Click the button below to login!</p>
-      <Button type="button" size="lg" className="copy-btn" onClick={signInGoHome}>
-        Sign In
-      </Button>
-    </div>
+    <>
+      <div className="bg-positive-top" />
+      <div className="bg-negative-top" />
+      <div className="bg-positive-bottom" />
+      <div className="bg-negative-bottom" />
+      <div
+        className="text-center d-flex flex-column justify-content-center align-content-center"
+        style={{
+          height: '90vh',
+          padding: '30px',
+          maxWidth: '400px',
+          margin: '0 auto',
+        }}
+      >
+        <button type="button" className="signin-btn" onClick={signInGoHome}>
+          SIGN IN
+        </button>
+      </div>
+      <div className="welcome-title logo">
+        <h3>A</h3>
+        <h1>TRIVIAL</h1>
+        <h2>GLANCE</h2>
+      </div>
+    </>
   );
 }
 

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,9 +1,8 @@
 /* eslint-disable react/prop-types */
 import 'bootstrap/dist/css/bootstrap.min.css';
-// import NoAuth from '../components/NoAuth'; // TODO: COMMENT OUT FOR AUTH
 import '../styles/globals.css';
-import { AuthProvider } from '../utils/context/authContext'; // TODO: COMMENT IN FOR AUTH
-import ViewDirectorBasedOnUserAuthStatus from '../utils/ViewDirector'; // TODO: COMMENT IN FOR AUTH
+import { AuthProvider } from '../utils/context/authContext';
+import ViewDirectorBasedOnUserAuthStatus from '../utils/ViewDirector';
 
 function MyApp({ Component, pageProps }) {
   return (
@@ -13,7 +12,6 @@ function MyApp({ Component, pageProps }) {
         pageProps={pageProps}
       /> */}
 
-      {/* TODO: Delete NoAuth component above and comment in code below for authentication */}
       <AuthProvider>
         <ViewDirectorBasedOnUserAuthStatus
           // if status is pending === loading

--- a/pages/game/[id].js
+++ b/pages/game/[id].js
@@ -102,7 +102,7 @@ export default function PlayGame() {
   }, []);
 
   return (
-    <div>
+    <>
       {!teamCheck || (yourTeam.firebaseKey && !game.status) ? (
         'Loading...'
       ) : (
@@ -126,6 +126,6 @@ export default function PlayGame() {
           )}
         </>
       )}
-    </div>
+    </>
   );
 }

--- a/pages/games.js
+++ b/pages/games.js
@@ -14,17 +14,19 @@ export default function PlayerGameSelect() {
 
   return (
     <>
-      <div className="games-header">
-        <h1 className="page-header">Live Games</h1>
+      <div className="header">
+        <h1>Live Games</h1>
       </div>
-      <div className="games-container">
-        {openGames.length > 0 ? (
-          openGames
-            .sort((a, b) => a.name.localeCompare(b.name))
-            .map((game) => <GameCard key={game.firebaseKey} gameObj={game} />)
-        ) : (
-          <span>Loading Games</span>
-        )}
+      <div className="content">
+        <div className="games-container">
+          {openGames.length > 0 ? (
+            openGames
+              .sort((a, b) => a.name.localeCompare(b.name))
+              .map((game) => <GameCard key={game.firebaseKey} gameObj={game} />)
+          ) : (
+            <span>Loading Games</span>
+          )}
+        </div>
       </div>
     </>
   );

--- a/pages/host/game/[id].js
+++ b/pages/host/game/[id].js
@@ -65,9 +65,9 @@ export default function ManageGame() {
   }, [gameData?.status]);
 
   return (
-    <div>
+    <>
       {gameData && (<GameDisplay game={gameData} host onUpdate={grabGame} />)}
       {gameData?.status === 'live' && (<HostResponsePanel responses={responses} onUpdate={grabResponses} />)}
-    </div>
+    </>
   );
 }

--- a/pages/host/game/edit/[id].js
+++ b/pages/host/game/edit/[id].js
@@ -18,9 +18,9 @@ export default function EditGame() {
   }, []);
 
   return (
-    <div>
-      <h1 className="page-header">Edit Game</h1>
+    <>
+      <h1 className="header">Edit Game</h1>
       {game && (<GameForm gameObj={game} />)}
-    </div>
+    </>
   );
 }

--- a/pages/host/game/new.js
+++ b/pages/host/game/new.js
@@ -3,9 +3,11 @@ import GameForm from '../../../components/forms/GameForm';
 
 export default function CreateGame() {
   return (
-    <div>
-      <h1 className="page-header">New Game</h1>
-      <GameForm />
-    </div>
+    <>
+      <h1 className="header">New Game</h1>
+      <div className="content">
+        <GameForm />
+      </div>
+    </>
   );
 }

--- a/pages/host/games.js
+++ b/pages/host/games.js
@@ -20,20 +20,22 @@ export default function HostGames() {
 
   return (
     <>
-      <div className="games-header">
-        <h1 className="page-header">Games</h1>
+      <div className="header">
+        <h1>Games</h1>
         <Link passHref href="/host/game/new">
           <button type="button" className="">New Game</button>
         </Link>
       </div>
-      <div className="games-container">
-        {games ? (
-          games
-            .sort((a, b) => a.name.localeCompare(b.name))
-            .map((game) => <GameCard key={game.firebaseKey} gameObj={game} host />)
-        ) : (
-          <span>Loading Games</span>
-        )}
+      <div className="content">
+        <div className="games-container">
+          {games ? (
+            games
+              .sort((a, b) => a.name.localeCompare(b.name))
+              .map((game) => <GameCard key={game.firebaseKey} gameObj={game} host />)
+          ) : (
+            <span>Loading Games</span>
+          )}
+        </div>
       </div>
     </>
   );

--- a/pages/host/question/[id]/[gameQuestionId].js
+++ b/pages/host/question/[id]/[gameQuestionId].js
@@ -46,9 +46,9 @@ export default function ManageGameQuestion() {
   }, [question.status]);
 
   return (
-    <div>
+    <>
       {question.firebaseKey && (<QuestionDetails questionObj={question} host onUpdate={onUpdate} />)}
       {question?.game?.status === 'live' && (<HostResponsePanel responses={responses} onUpdate={onUpdate} />)}
-    </div>
+    </>
   );
 }

--- a/pages/host/question/new.js
+++ b/pages/host/question/new.js
@@ -3,9 +3,9 @@ import QuestionForm from '../../../components/forms/QuestionForm';
 
 export default function CreateQuestion() {
   return (
-    <div>
-      <h1 className="page-header">New Question</h1>
+    <>
+      <h1 className="header">New Question</h1>
       <QuestionForm />
-    </div>
+    </>
   );
 }

--- a/pages/host/questions.js
+++ b/pages/host/questions.js
@@ -20,18 +20,20 @@ export default function HostQuestions() {
 
   return (
     <>
-      <div className="questions-header">
-        <h1 className="page-header">Questions</h1>
+      <div className="header">
+        <h1>Questions</h1>
         <Link passHref href="/host/question/new">
           <button type="button" className="">New Question</button>
         </Link>
       </div>
-      <div className="question-container">
-        {questions.length ? (
-          questions.map((q) => <QuestionCard key={q.firebaseKey} questionObj={q} host />)
-        ) : (
-          <span>Loading Questions</span>
-        )}
+      <div className="content">
+        <div className="question-container">
+          {questions.length ? (
+            questions.map((q) => <QuestionCard key={q.firebaseKey} questionObj={q} host />)
+          ) : (
+            <span>Loading Questions</span>
+          )}
+        </div>
       </div>
     </>
   );

--- a/pages/index.js
+++ b/pages/index.js
@@ -29,7 +29,7 @@ function Home() {
         </button>
         <p className="signout-username">{`(Logged in as ${user.displayName})`}</p>
       </div>
-      <div className="welcome-title">
+      <div className="welcome-title logo">
         <h3>A</h3>
         <h1>TRIVIAL</h1>
         <h2>GLANCE</h2>

--- a/pages/question/[id]/[gameQuestionId].js
+++ b/pages/question/[id]/[gameQuestionId].js
@@ -30,8 +30,8 @@ export default function ReviewGameQuestion() {
   }, []);
 
   return (
-    <div>
+    <>
       {question.question && <QuestionDetails questionObj={question} />}
-    </div>
+    </>
   );
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -10,6 +10,11 @@ body {
     Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
 }
 
+.logo {
+  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
+    Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+}
+
 :root {
   --main-color-1: #555959;
   --btn-shadow-up: inset 0 0 5px black, inset 2px 2px 5px 0 #e5e9e975, 2px 2px 3px black;
@@ -28,6 +33,17 @@ a {
 body {
   background-color: var(--main-color-1);
 }
+
+.app-container {
+  position: fixed;
+  display: flex;
+  flex-flow: column nowrap;
+  width: 100%;
+  top: 0;
+  bottom: 0;
+  overflow: hidden;
+}
+
 
 .bg-positive-top {
   position: fixed;
@@ -66,6 +82,129 @@ body {
   height: 200px;
   background: var(--main-color-1);
   border-radius: 50%;
+}
+
+.welcome-title {
+  position: fixed;
+  left: 5vw;
+  bottom: 20vh;
+  color: aliceblue;
+  text-shadow: 6px 6px black;
+  h1, h2, h3 {
+    padding: 0;
+    margin: 0;
+  }
+  h1 {
+    position: absolute;
+    top: -161px;
+    left: 25px;
+    font-size: 150px;
+  }
+  h2 {
+    position: absolute;
+    top: -42px;
+    font-size: 100px;
+  }
+  h3 {
+    position: absolute;
+    top: -188px;
+    font-size: 75px;
+  }
+}
+.title-watermark {
+  z-index: -2;
+  color: var(--main-color-1);
+  transform: rotate(17deg) scale(0.7);
+  left: 5px;
+  bottom: 80px;
+}
+
+.signin-btn {
+  background: rgb(37, 37, 37);
+  border: none;
+  border-radius: 5px;
+  color: aliceblue;
+  width: 200px;
+  font-size: 20px;
+  box-shadow: var(--btn-shadow-up);
+  margin: 0 auto;
+}
+
+.welcome-buttons {
+  width: 400px;
+  margin: 0 auto;
+  padding-top: 35vh;
+  display: flex;
+  justify-content: center;
+  gap: 50px;
+  color: aliceblue;
+  text-align: center;
+  button {
+    background: rgb(37, 37, 37);
+    border: none;
+    border-radius: 5px;
+    color: aliceblue;
+    width: 100px;
+    font-size: 20px;
+    box-shadow: var(--btn-shadow-up);
+  }
+  button:hover {
+    background: black;
+  }
+  button:active {
+    box-shadow: var(--btn-shadow-down);
+  }
+}
+.welcome-signout {
+  position: fixed;
+  right: 5vw;
+  bottom: 5vh;
+  color: aliceblue;
+  text-align: center;
+  button {
+    border: none;
+    background: none;
+    color: inherit;
+  }
+  button:hover {
+    color:#b5b9b9;
+  }
+  .signout-user-image {
+    height: 20px;
+    width: 20px;
+    border-radius: 50%;
+    object-fit: cover;
+    margin-left: 5px;
+    margin-bottom: 2px;
+  }
+  .signout-username {
+    font-style: italic;
+    font-size: 0.7rem;
+    margin: 0;
+    color: rgb(182, 188, 192);
+  }
+}
+
+.header {
+  width: 80%;
+  margin: 0 auto;
+  text-align: center;
+  height: 30%;
+  h1 {
+    font-size: 10rem;
+    color: aliceblue;
+    text-shadow: 8px 8px black;
+  }
+}
+
+.content {
+  position: relative;
+  width: 100%;
+  flex: 1;
+  padding-bottom: 50px;
+  margin: 0 auto;
+  color: aliceblue;
+  overflow-y: hidden;
 }
 
 input:focus {
@@ -171,108 +310,13 @@ input:focus {
 }
 
 
-.welcome-buttons {
-  width: 400px;
-  margin: 0 auto;
-  padding-top: 35vh;
-  display: flex;
-  justify-content: center;
-  gap: 50px;
-  color: aliceblue;
-  text-align: center;
-  button {
-    background: rgb(37, 37, 37);
-    border: none;
-    border-radius: 5px;
-    color: aliceblue;
-    width: 100px;
-    font-size: 20px;
-    box-shadow: var(--btn-shadow-up);
-  }
-  button:hover {
-    background: black;
-  }
-  button:active {
-    box-shadow: var(--btn-shadow-down);
-  }
-}
-
-.welcome-signout {
-  position: fixed;
-  right: 5vw;
-  bottom: 5vh;
-  color: aliceblue;
-  text-align: center;
-  button {
-    border: none;
-    background: none;
-    color: inherit;
-  }
-  button:hover {
-    color:#b5b9b9;
-  }
-  .signout-user-image {
-    height: 20px;
-    width: 20px;
-    border-radius: 50%;
-    object-fit: cover;
-    margin-left: 5px;
-    margin-bottom: 2px;
-  }
-  .signout-username {
-    font-style: italic;
-    font-size: 0.7rem;
-    margin: 0;
-    color: rgb(182, 188, 192);
-  }
-}
-
-.welcome-title {
-  position: fixed;
-  left: 5vw;
-  bottom: 20vh;
-  color: aliceblue;
-  text-shadow: 6px 6px black;
-  h1, h2, h3 {
-    padding: 0;
-    margin: 0;
-  }
-  h1 {
-    position: absolute;
-    top: -161px;
-    left: 25px;
-    font-size: 150px;
-  }
-  h2 {
-    position: absolute;
-    top: -42px;
-    font-size: 100px;
-  }
-  h3 {
-    position: absolute;
-    top: -188px;
-    font-size: 75px;
-  }
-}
-.title-watermark {
-  z-index: -2;
-  color: var(--main-color-1);
-  transform: rotate(17deg) scale(0.7);
-  left: 5px;
-  bottom: 80px;
-}
-
-.page-header {
-  font-size: 10rem;
-  color: aliceblue;
-  text-shadow: 8px 8px black;
-}
 
 .question-container, .games-container {
   display: flex;
   flex-flow: row wrap;
   gap: 10px calc((100% - 1200px)/3);
   justify-content: space-between;
+
 }
 
 .g-card {
@@ -374,7 +418,7 @@ input:focus {
   margin-right: auto;
 }
 .q-card:hover {
-  max-height: 200px;
+  max-height: 300px;
 }
 .q-card:active {
   box-shadow: var(--btn-shadow-down);
@@ -702,148 +746,155 @@ input:focus {
   }
 }
 
-
-.game-display {
-  color: aliceblue;
-  width: 100%;
-  height: 96vh;
+.gd-header {
+  position: relative;
+  text-align: center;
+  padding-top: 10px;
   display: flex;
-  flex-flow: column;
-  .gd-header {
-    position: relative;
-    width: 100%;
-    text-align: center;
-    margin-top: 10px;
-    display: flex;
-    gap: 40px;
-    .gd-title-box {
-      flex: 1;
-      h1, h2 {
-        text-shadow: 4px 4px black;
-      }
-      h1 {
-        font-size: 4rem;
-        margin: 0;
-        display: inline-block;
-      }
-      h2 {
-        font-size: 2rem;
-        font-style: italic;
-      }
+  gap: 40px;
+  color: aliceblue;
+  height: auto;
+  .gd-title-box {
+    flex: 1;
+    h1, h2 {
+      text-shadow: 4px 4px black;
     }
-    .gd-header-buttons {
-      display: flex;
-      gap: 5px;
-      width: auto;
-      div {
-        width: 150px;
-      }
-      .gd-game-status {
-        display: block;
-        position: relative;
-        font-size: 1.2rem;
-        color: black;
-        border-radius: 5px;
-        padding: 3px 10px;
-        box-shadow: var(--btn-shadow-up);
-        border: 1px solid black;
-        width: 100%;
-        margin-bottom: 5px;
-        height: 36px;
-        pointer-events: none;
-        p {
-          position: absolute;
-          margin: 0;
-          bottom: 0px;
-          right: 0px;
-          font-size: 0.6rem;
-          background-color: #35393990;
-          padding: 1px 3px;
-          border-radius: 5px 1px 5px 1px;
-          color: rgba(240, 248, 255, 0.803);
-          text-shadow: 1px 1px 1px black;
-        }
-      }
-      button {
-        display: block;
-        border-radius: 5px;
-        border: none;
-        margin-bottom: 5px;
-        font-size: 1rem;
-        padding: 5px 10px;
-        width: 100%;
-        min-height: 36px;
-        box-shadow: var(--btn-shadow-up);
-        align-content: center;
-        background-color: #353939;
-        color: aliceblue;
-      }
-      button:active {
-        box-shadow: var(--btn-shadow-down);
-        border: 1px solid #353939;
-      }
-      button:hover {
-        background: black;
-      }
-      .gd-status-toggle-live:hover {
-        background-color: #82e782;
-        color: black;
-      }
-      .gd-status-toggle-closed:hover {
-        background-color: #e67c7c;
-        color: black;
-      }
-      .gd-status-reset:hover {
-        background-color: #b5b9b9;
-        color: black;
-      }
+    h1 {
+      font-size: 4rem;
+      margin: 0;
+      display: inline-block;
+    }
+    h2 {
+      font-size: 2rem;
+      font-style: italic;
     }
   }
-  .gd-container {
-    position: relative;
+  .gd-header-buttons {
     display: flex;
-    flex: 1;
-    height: 100%;
-    overflow-x: auto;
-    overflow-y: hidden;
-    scrollbar-width: none;
-    .gd-unused, .gd-open-host, .gd-open-player, .gd-closed, .gd-released {
+    gap: 5px;
+    width: auto;
+    div {
+      width: 150px;
+    }
+    .gd-game-status {
+      display: block;
       position: relative;
-      border-left: 2px solid aliceblue;
-      padding: 0 5px;
-      margin: 10px 0 0 0;
-      height: 100%;
-      h3 {
-        width: 100%;
-        height: 36px;
-        text-align: center;
-        text-shadow: 3px 3px black;
+      font-size: 1.2rem;
+      color: black;
+      border-radius: 5px;
+      padding: 3px 10px;
+      box-shadow: var(--btn-shadow-up);
+      border: 1px solid black;
+      width: 100%;
+      margin-bottom: 5px;
+      height: 36px;
+      pointer-events: none;
+      p {
+        position: absolute;
         margin: 0;
+        bottom: 0px;
+        right: 0px;
+        font-size: 0.6rem;
+        background-color: #35393990;
+        padding: 1px 3px;
+        border-radius: 5px 1px 5px 1px;
+        color: rgba(240, 248, 255, 0.803);
+        text-shadow: 1px 1px 1px black;
       }
+    }
+    button {
+      display: block;
+      border-radius: 5px;
+      border: none;
+      margin-bottom: 5px;
+      font-size: 1rem;
+      padding: 5px 10px;
+      width: 100%;
+      min-height: 36px;
+      box-shadow: var(--btn-shadow-up);
+      align-content: center;
+      background-color: #353939;
+      color: aliceblue;
+    }
+    button:active {
+      box-shadow: var(--btn-shadow-down);
+      border: 1px solid #353939;
+    }
+    button:hover {
+      background: black;
+    }
+    .gd-status-toggle-live:hover {
+      background-color: #82e782;
+      color: black;
+    }
+    .gd-status-toggle-closed:hover {
+      background-color: #e67c7c;
+      color: black;
+    }
+    .gd-status-reset:hover {
+      background-color: #b5b9b9;
+      color: black;
+    }
+  }
+}
+.gd-container {
+  position: relative;
+  display: flex;
+  flex: 1;
+  height: 100%;
+  width: 100%;
+  padding: 0 10px;
+  justify-content: center;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: none;
+  .gd-unused, .gd-open-closed-host, .gd-open-player, .gd-released {
+    position: relative;
+    border-left: 2px solid aliceblue;
+    padding: 0 5px;
+    margin: 10px 0 0 0;
+    height: calc(100% - 10px);
+    width: 345px;
+    min-width: 345px;
+    h3 {
+      width: 100%;
+      height: 36px;
+      min-height: 36px;
+      text-align: center;
+      text-shadow: 3px 3px black;
+      margin: 0;
+    }
+    .gd-fade-captive {
+      position: relative;
+      height: calc(100% - 56px);
+      width: calc(100% - 30px);
+      margin: 10px auto;
+      border-radius: 5px;
+      box-shadow: 0 0 3px 2px black;
+      background: #353939;
+      border: 1px solid black;
+      overflow-y: hidden;
       .gd-card-container {
         display: flex;
         flex-flow: row wrap;
         gap: 10px;
-        justify-content: center;
-        width: 300px;
+        justify-content: space-around;
+        width: calc(100% - 20px);
         margin: 0 auto;
+        padding: 10px 0;
         max-height: 100%;
         height: 100%;
         overflow-y: auto;
         scrollbar-width: none;
         scrollbar-color: #00000050 var(--main-color-1);
         align-content: flex-start;
-        .q-card:first-of-type {
-          margin-top: 10px;
-        }
         .q-card:last-of-type {
           margin-right: 0;
-          margin-bottom: 10px;
         }
       }
       .gd-scroll-fade {
         height: calc(100% + 2px);
-        width: 298px;
+        width: calc(100% - 2px);
         margin: 0 auto;
         position: absolute;
         top: -1px;
@@ -852,82 +903,112 @@ input:focus {
         box-shadow: inset 0 30px 6px -20px #353939, inset 0 -30px 6px -20px #353939;
         pointer-events: none;
       }
-      .gd-fade-captive {
-        position: relative;
-        height: calc(94% - 36px);
-        width: 300px;
-        margin: 10px auto;
-        border-radius: 5px;
-        box-shadow: 0 0 3px 2px black;
-        background: #353939;
-        border: 1px solid black;
-      }
-    }
-    .gd-unused {
-      width: 330px;
-    }
-    .gd-open-host {
-      width: 330px;
-    }
-    .gd-open-player {
-      flex: 1;
-      min-width: 330px;
-      overflow-y: hidden;
-      h2 {
-        width: 100%;
-        text-align: center;
-      }
-      .gd-open-tags {
-        float: right;
-        width: auto;
-        align-content: center;
-        margin: 0 6px;
-        padding: 5px 0 0 0;
-        text-align: right;
-      }
-      .gd-open-category, .gd-open-status {
-        display: inline-block;
-        border-radius: 5px;
-        font-size: 1rem;
-        padding: 5px 10px;
-        box-shadow: inset 0 0 3px black;
-        width: auto;
-        margin: 0 2px;
-        color: black;
-      }
-      hr {
-        width: calc(100% - 10px);
-        margin: 10px auto;
-      }
-      .gd-open-question {
-        font-size: 2rem;
-        width: 100%;
-        height: 90%;
-        text-align: center;
-        margin-top: 5px;
-        padding-bottom: 20px;
-        overflow-y: scroll;
-        scrollbar-width: none;
-      }
-      .gd-image {
-        display: block;
-        max-height: 300px;
-        border: 1px solid black;
-        border-radius: 5px;
-        box-shadow: 0 0 3px black;
-        margin: 0 auto;
-      }
-    }
-    .gd-closed {
-      width: 330px;
-    }
-    .gd-released {
-      border-right: 2px solid aliceblue;
-      margin-top: 10px;
-      padding: 0 5px;
-      width: 330px;
     }
   }
+  .gd-unused {
+    width: 635px;
+    min-width: 635px;
+    .unused-highlight {
+      box-shadow: 0 0 3px 2px #b5b9b9;
+    }
+    .gd-fade-captive {
+      .gd-card-container {
+        .q-card:last-of-type {
+          margin-right: auto;
+        }
+      }
+    }
+  }
+  .gd-open-closed-host {
+    position: relative;
+    display: flex;
+    flex-flow: column nowrap;
+    .open-highlight {
+      box-shadow: 0 0 3px 2px #82e782;
+    }
+    .closed-highlight {
+      box-shadow: 0 0 3px 2px #e67c7c;
+    }
+    .gd-col-header {
+      position: relative;
+      height: 36px;
+      .gd-close-q, .gd-release-all {
+        position: absolute;
+        top: 4px;
+        right: 15px;
+      }
+    }
+    .gd-fc-open {
+      height: auto;
+      min-height: 78px;
+      .gd-card-container {
+        .q-card {
+          max-height: 300px;
+        }
+      }
+    }
+    .gd-fc-closed {
+      flex: 1 78px;
+      /* height: 78px; */
+    }
+  }
+  .gd-released {
+    border-right: 2px solid aliceblue;
+    .released-highlight {
+      box-shadow: 0 0 3px 2px aliceblue;
+    }
+  }
+  .gd-open-player {
+    flex: 1 635px;
+    max-width: 1000px;
+    min-width: 635px;
+    overflow-y: hidden;
+    h2 {
+      width: 100%;
+      text-align: center;
+    }
+    .gd-open-tags {
+      float: right;
+      width: auto;
+      align-content: center;
+      margin: 0 6px;
+      padding: 5px 0 0 0;
+      text-align: right;
+    }
+    .gd-open-category, .gd-open-status {
+      display: inline-block;
+      border-radius: 5px;
+      font-size: 1rem;
+      padding: 5px 10px;
+      box-shadow: inset 0 0 3px black;
+      width: auto;
+      margin: 0 2px;
+      color: black;
+    }
+    hr {
+      width: calc(100% - 10px);
+      margin: 10px auto;
+    }
+    .gd-open-question {
+      font-size: 2rem;
+      width: 100%;
+      height: 90%;
+      text-align: center;
+      margin-top: 5px;
+      padding-bottom: 20px;
+      overflow-y: scroll;
+      scrollbar-width: none;
+    }
+    .gd-image {
+      display: block;
+      max-height: 300px;
+      border: 1px solid black;
+      border-radius: 5px;
+      box-shadow: 0 0 3px black;
+      margin: 0 auto;
+    }
+  }
+  
 }
 
 .team-form {

--- a/utils/ViewDirector.js
+++ b/utils/ViewDirector.js
@@ -23,11 +23,11 @@ const ViewDirectorBasedOnUserAuthStatus = ({ component: Component, pageProps }) 
         <div className="bg-positive-bottom" />
         <div className="bg-negative-bottom" />
         {router.pathname !== '/' && (<NavBarAuth />)}
-        <div className="container">
+        <div className="app-container">
           <Component {...pageProps} />
         </div>
         {router.pathname !== '/' && (
-          <div className="welcome-title title-watermark">
+          <div className="welcome-title title-watermark logo">
             <h3>A</h3>
             <h1>TRIVIAL</h1>
             <h2>GLANCE</h2>


### PR DESCRIPTION
## Description
Host users can adjust question status directly on /host/game/[id] page through drag and drop between columns
Also added buttons to /host/game/[id] to close an open question or release answers for all closed questions

Regrouped page into header/content divs to improve styling control
Added bg elements to and styled sign-in page

Fixed a couple undefined data as they presented

## Related Issue
NA

## Motivation and Context
As a host user, it was tedious to navigate to a gameQuestion page to toggle the game status. So I wanted tools to change a question's status directly on the game display

Styling changes will make media queries/responsiveness easier to manage

## How Can This Be Tested?
Navigate to a game's details page as a host. When the game is closed, most drag and drop functionality (apart from resetting questions) is locked. With game live, move questions between the four panels and check that behavior is as expected. Open a second panel as a player in that game to view effects of drag and drop.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
