### PR TITLE
Styling bugs

### DIFF
--- a/components/forms/GameDropdown.js
+++ b/components/forms/GameDropdown.js
@@ -94,7 +94,7 @@ export default function GameDropdown() {
             {assigned.map((gq) => (
               <div key={gq.firebaseKey} className="assigned-game">
                 <Link passHref href={`/host/question/${router.query.id}/${gq.firebaseKey}`}>
-                  <button type="button">
+                  <button type="button" className="qd-gq-btn">
                     <div className="qd-gq-status"><span className={`status-tag status-${gq.status}`}>{gq.status.toUpperCase()}</span> in</div>
                     <div className="qd-gq-game">{gq.name}</div>
                   </button>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -658,14 +658,16 @@ input:focus {
           border-radius: 5px;
           box-shadow: inset 0 0 3px black;
           margin-bottom: 5px;
-          button {
+          .qd-gq-btn {
             background: none;
             border: none;
             color: inherit;
-            width: 100%;
-            margin: 0 auto 0 0;
+            width: 100% !important;
           }
           .gq-remove {
+            background: none;
+            border: none;
+            color: inherit;
             position: absolute;
             top: 3px;
             right: 3px;
@@ -714,6 +716,7 @@ input:focus {
           }
           .qd-game-toggle {
             background: none;
+            color: black;
             border: none;
             border-radius: 0 4px 4px 0;
             margin: 0 0 0 auto;
@@ -1778,6 +1781,7 @@ input:focus {
         .qd-category {
           min-height: 30px;
           font-size: 0.8rem;
+          width: auto;
           min-width: 100px;
           .qd-category-name {
             padding: 5px 7px;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- DELETE ALL COMMENTS BEFORE CREATING PULL REQUEST -->

## Description
Added !important to background color
Removed temporary dev coloring in watermark for media queries
Fixed bug where category dropdown does not display in mobile view
Attempted to address issue with game names not filling full assigned game card in GameDropdown

Removed all window.confirms (unresponsive on iPhone) will replace with interrupt component in future

## Related Issue
Styling bugs

## Motivation and Context
Some styling issues present upon Netlify deployment

## How Can This Be Tested?
Go to a-trivial-glance.netlify.app and check for proper background coloring, functionality on previous tasks that required confirms (delete and reset), category dropdown on mobile

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
